### PR TITLE
remove nonroot user from openshift Dockerfile

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -25,6 +25,4 @@ COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/bindata/deployment /bindata/deployment
 COPY --from=builder /workspace/bindata/configuration/address-pool/ /bindata/configuration/address-pool
 
-USER nonroot:nonroot
-
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
remove nonroot USER not able to test ART operator image I get the following error
```
docker run -it registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-metallb-operator:rhaos-4.9-rhel-8-containers-hotfix-22228-20210623043520 bash -c "ls -l"
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
Error: unable to find user nonroot: no matching entries in passwd file
```