### PR TITLE
WIP Modify metallb manifest to enable OCP deploment

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -13,6 +13,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 COPY vendor/ vendor/
 COPY bindata/deployment/ bindata/deployment/
+COPY bindata/ocpdeployment/ bindata/ocpdeployment/
 COPY bindata/configuration/address-pool/ bindata/configuration/address-pool/
 
 # Build
@@ -20,9 +21,12 @@ RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -o manager main.go
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.9
 
+ENV OCP_PLATFORM=1
+
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/bindata/deployment /bindata/deployment
+COPY --from=builder /workspace/bindata/ocpdeployment /bindata/ocpdeployment
 COPY --from=builder /workspace/bindata/configuration/address-pool/ /bindata/configuration/address-pool
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Metallb manifest need to be modified to work on OCP based on this
[metallb-on-openshift-ocp](https://metallb.universe.tf/installation/clouds/#metallb-on-openshift-ocp)
I checked podSecurity for speaker and it has privileged set to true
```
  name: speaker
  ownerReferences:
  - apiVersion: metallb.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: Metallb
    name: metallb
    uid: cf10f972-4364-4440-b77c-dc1f88680fa8
  resourceVersion: "8831611"
  uid: 95d2a90d-2db8-4f82-857f-47843ae87ea7
spec:
  allowPrivilegeEscalation: false
  allowedCapabilities:
  - NET_RAW
  defaultAllowPrivilegeEscalation: false
  fsGroup:
    rule: RunAsAny
  hostNetwork: true
  hostPorts:
  - max: 7472
    min: 7472
  - max: 7946
    min: 7946
  privileged: true
```
w/o this change we will get the following error
```
provider "anyuid": Forbidden: not usable by
user or serviceaccount, spec.containers[0].securityContext.runAsUser: Invalid
value: 65534: must be in the ranges: [1000710000, 1000719999]
```

depends on https://github.com/metallb/metallb-operator/pull/44