### PR TITLE
Bug 1987136: Declare supported arches in CSV

### DIFF
--- a/manifests/4.9/metallb-operator.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/metallb-operator.v4.9.0.clusterserviceversion.yaml
@@ -67,6 +67,8 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/metallb/metallb-operator
     support: Community
+  labels:
+    operatorframework.io/arch.amd64: supported
   name: metallb-operator.v4.9.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
The OperatorHub currently assumes x86-only for any operators which do
not declare any such labels.  Declaring these explicitly should make the
current status more obvious in the code, and make it easier to correctly
add further architectures when conditions warrant.
