### PR TITLE
Bug 1991316: Update MetalLB CSV namespace to start with openshift prefix

### DIFF
--- a/manifests/4.9/metallb-operator.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/metallb-operator.v4.9.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
           "kind": "AddressPool",
           "metadata": {
             "name": "addresspool-sample1",
-            "namespace": "metallb-system"
+            "namespace": "openshift-metallb-system"
           },
           "spec": {
             "addresses": [
@@ -23,7 +23,7 @@ metadata:
           "kind": "AddressPool",
           "metadata": {
             "name": "addresspool-sample2",
-            "namespace": "metallb-system"
+            "namespace": "openshift-metallb-system"
           },
           "spec": {
             "addresses": [
@@ -38,7 +38,7 @@ metadata:
           "kind": "AddressPool",
           "metadata": {
             "name": "addresspool-sample3",
-            "namespace": "metallb-system"
+            "namespace": "openshift-metallb-system"
           },
           "spec": {
             "addresses": [
@@ -52,7 +52,7 @@ metadata:
           "kind": "MetalLB",
           "metadata": {
             "name": "metallb",
-            "namespace": "metallb-system"
+            "namespace": "openshift-metallb-system"
           }
         }
       ]


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
Update manifest's MetalLB namespace