### PR TITLE
Bug 1994979: Fix olm.skipRange replacements

### DIFF
--- a/manifests/4.9/metallb-operator.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/metallb-operator.v4.9.0.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-metallb-operator:4.9
     createdAt: "2021-06-28 00:00:00"
-    olm.skipRange: ">=4.8.0-0 < 4.9.0-0"
+    olm.skipRange: ">=4.8.0 <4.9.0"
     description: An operator for deploying MetalLB on a kubernetes cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.8.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2

--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -7,8 +7,8 @@ updates:
       replace: "metallb-operator.{FULL_VER}"
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
-    - search: 'olm.skipRange: ">=4.8-0 <{MAJOR}.{MINOR}.0"'
-      replace: 'olm.skipRange: ">=4.8-0 <{FULL_VER}"'
+    - search: 'olm.skipRange: ">=4.8.0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.8.0 <{FULL_VER}"'
   - file: "metallb-operator.package.yaml"
     update_list:
     - search: "currentCSV: metallb-operator.v{MAJOR}.{MINOR}.0"


### PR DESCRIPTION
The skipRange replacement has been a no-op. This change makes it
effective.