### PR TITLE
Fix the 4.9 reference in the CI bundle Dockerfile

### DIFF
--- a/bundleci.Dockerfile
+++ b/bundleci.Dockerfile
@@ -15,6 +15,6 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 # Copy files to locations specified by labels.
-COPY manifests/4.9/*.yaml /manifests/
+COPY manifests/4.10/*.yaml /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/


### PR DESCRIPTION
This repo is aiming at 4.10 now, this is a leftover from bumping the manifests.