### PR TITLE
Set FRR mode as the default METALLB_BGP_TYPE

### DIFF
--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -376,7 +376,7 @@ spec:
                       - name: ENABLE_OPERATOR_WEBHOOK
                         value: "true"
                       - name: METALLB_BGP_TYPE
-                        value: native
+                        value: frr
                       - name: FRR_IMAGE
                         value: frrouting/frr:v7.5.1
                       - name: WATCH_NAMESPACE

--- a/config/manager/env.yaml
+++ b/config/manager/env.yaml
@@ -16,6 +16,6 @@ spec:
             - name: ENABLE_OPERATOR_WEBHOOK
               value: "true"
             - name: METALLB_BGP_TYPE
-              value: "native"
+              value: "frr"
             - name: FRR_IMAGE
               value: "frrouting/frr:v7.5.1"


### PR DESCRIPTION
We only support the FRR BGP mode d/s,
setting it here as default. This shouldn't
be changed by the users.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>