### PR TITLE
Bug 2041483: Add kube-rbac-proxy to image refs

### DIFF
--- a/manifests/4.10/image-references
+++ b/manifests/4.10/image-references
@@ -15,3 +15,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-metallb-frr:4.10
+  - name: kube-rbac-proxy
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-kube-rbac-proxy:4.10            


### PR DESCRIPTION
Kube-rbac-proxy was missing, so ART won't replacing it with the image from brew.