### PR TITLE
Bug 2041087: MetalLB CR yaml was enforcing nodeSelector which is an optional config

### DIFF
--- a/manifests/4.10/metallb-operator.v4.10.0.clusterserviceversion.yaml
+++ b/manifests/4.10/metallb-operator.v4.10.0.clusterserviceversion.yaml
@@ -171,11 +171,6 @@ metadata:
             "name": "metallb",
             "namespace": "openshift-metallb-system"
           },
-          "spec": {
-            "nodeSelector": {
-              "feature.node.kubernetes.io/metalLB.capable": "true"
-            }
-          }
         }
       ]
     capabilities: Basic Install


### PR DESCRIPTION
remove nodeSelector from clustersvc manifest as it was enforcing the users of metallb CR to configure nodeSelector which is an optional configuration and not mandatory.
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>