### PR TITLE
Bug 2051722: Add ebgpMultihop to OCP 4.10 manifest

### DIFF
--- a/manifests/4.10/metallb.io_bgppeers.yaml
+++ b/manifests/4.10/metallb.io_bgppeers.yaml
@@ -36,6 +36,9 @@ spec:
             properties:
               bfdProfile:
                 type: string
+              ebgpMultiHop:
+                description: EBGP peer is multi-hops away
+                type: boolean
               holdTime:
                 description: Requested BGP hold time, per RFC4271.
                 type: string


### PR DESCRIPTION
Add ebgpMulti hop field to OCP 4.10 manifest
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>