### PR TITLE
Add the cluster-monitoring annotation

### DIFF
--- a/manifests/4.11/metallb-operator.v4.11.0.clusterserviceversion.yaml
+++ b/manifests/4.11/metallb-operator.v4.11.0.clusterserviceversion.yaml
@@ -182,6 +182,7 @@ metadata:
     description: An operator for deploying MetalLB on a kubernetes cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.8.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
+    operatorframework.io/cluster-monitoring: true
     repository: https://github.com/openshift/metallb-operator
     support: Red Hat
   labels:

--- a/manifests/stable/metallb-operator.clusterserviceversion.yaml
+++ b/manifests/stable/metallb-operator.clusterserviceversion.yaml
@@ -182,6 +182,7 @@ metadata:
     description: An operator for deploying MetalLB on a kubernetes cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.8.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
+    operatorframework.io/cluster-monitoring: true
     repository: https://github.com/openshift/metallb-operator
     support: Red Hat
   labels:


### PR DESCRIPTION
According to https://github.com/openshift/enhancements/blob/master/enhancements/olm/olm-managed-operator-metrics.md
adding this label will make the ocp console add the monitoring label to
the namespace, and prometheus will be able to scrape our pods.
