### PR TITLE
Bug 2069705: Pin ports to allowed ranges

### DIFF
--- a/manifests/4.11/metallb-operator.v4.11.0.clusterserviceversion.yaml
+++ b/manifests/4.11/metallb-operator.v4.11.0.clusterserviceversion.yaml
@@ -412,6 +412,16 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: METRICS_PORT
+                  value: "29150"
+                - name: HTTPS_METRICS_PORT
+                  value: "9120"
+                - name: FRR_METRICS_PORT
+                  value: "29151"
+                - name: FRR_HTTPS_METRICS_PORT
+                  value: "9121"
+                - name: MEMBER_LIST_BIND_PORT
+                  value: "9122"
                 image: quay.io/openshift/origin-metallb-operator:4.11
                 name: manager
                 resources:

--- a/manifests/stable/metallb-operator.clusterserviceversion.yaml
+++ b/manifests/stable/metallb-operator.clusterserviceversion.yaml
@@ -412,6 +412,16 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: METRICS_PORT
+                  value: "29150"
+                - name: HTTPS_METRICS_PORT
+                  value: "9120"
+                - name: FRR_METRICS_PORT
+                  value: "29151"
+                - name: FRR_HTTPS_METRICS_PORT
+                  value: "9121"
+                - name: MEMBER_LIST_BIND_PORT
+                  value: "9122"
                 image: quay.io/openshift/origin-metallb-operator:4.11
                 name: manager
                 resources:


### PR DESCRIPTION
The speaker is a host networked pod. In order to have its endpoint
reacheable from outside, the exposed (https) ports must be in the
allowed range 9000-9999.