### PR TITLE
Check that deployment ready replicas greater than zero

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -183,7 +183,7 @@ var _ = Describe("validation", func() {
 					if err != nil {
 						return false
 					}
-					return deploy.Status.ReadyReplicas == deploy.Status.Replicas
+					return deploy.Status.ReadyReplicas > 0 && deploy.Status.ReadyReplicas == deploy.Status.Replicas
 				}, timeout, interval).Should(BeTrue())
 
 				pods, err := testclient.Client.Pods(OperatorNameSpace).List(context.Background(), metav1.ListOptions{


### PR DESCRIPTION
There is a case where both ReadyReplicas and Replicas are 0
and the Eventually passes. Adding this to avoid this situation.