### PR TITLE
Bug 2081788: CSV: fix the webhook type

### DIFF
--- a/manifests/4.11/metallb-operator.v4.11.0.clusterserviceversion.yaml
+++ b/manifests/4.11/metallb-operator.v4.11.0.clusterserviceversion.yaml
@@ -564,7 +564,7 @@ spec:
                   - /controller
                   env:
                     - name: METALLB_BGP_TYPE
-                      value: native
+                      value: frr
                   image: quay.io/openshift/origin-metallb:4.11
                   livenessProbe:
                     failureThreshold: 3

--- a/manifests/stable/metallb-operator.clusterserviceversion.yaml
+++ b/manifests/stable/metallb-operator.clusterserviceversion.yaml
@@ -564,7 +564,7 @@ spec:
                   - /controller
                   env:
                     - name: METALLB_BGP_TYPE
-                      value: native
+                      value: frr
                   image: quay.io/openshift/origin-metallb:4.11
                   livenessProbe:
                     failureThreshold: 3


### PR DESCRIPTION
We are using frr mode in openshift, the webhooks should be instructed accordingly.

Found this when running metallb's CI.
