### PR TITLE
Change the channel name to stable-v1

### DIFF
--- a/manifests/metallb-operator.package.yaml
+++ b/manifests/metallb-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: metallb-operator
 channels:
-- name: "stable"
+- name: "stable-v1"
   currentCSV: metallb-operator.v4.11.0


### PR DESCRIPTION
The upgrades between the 4.10 and the 4.11 versions won't work because
of the change of the scope of the operator.

Here we change the name of the channel to avoid automatic updates that
are not going to work.