### PR TITLE
Bug 2106770: Remove the service account manifests from the bundle

### DIFF
--- a/manifests/4.11/controller_v1_serviceaccount.yaml
+++ b/manifests/4.11/controller_v1_serviceaccount.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: metallb
-  name: controller

--- a/manifests/4.11/speaker_v1_serviceaccount.yaml
+++ b/manifests/4.11/speaker_v1_serviceaccount.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: metallb
-  name: speaker

--- a/manifests/stable/controller_v1_serviceaccount.yaml
+++ b/manifests/stable/controller_v1_serviceaccount.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: metallb
-  name: controller

--- a/manifests/stable/speaker_v1_serviceaccount.yaml
+++ b/manifests/stable/speaker_v1_serviceaccount.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: metallb
-  name: speaker


### PR DESCRIPTION
Getting the error: Error: Value controller: invalid service account found in bundle.
This service account controller in your bundle is not valid, because a service
account with the same name was already specified in your CSV
