### PR TITLE
Fix the bundleci docker file to refer to stable manifests

### DIFF
--- a/bundleci.Dockerfile
+++ b/bundleci.Dockerfile
@@ -15,6 +15,6 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 # Copy files to locations specified by labels.
-COPY manifests/4.11/*.yaml /manifests/
+COPY manifests/stable/*.yaml /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/


### PR DESCRIPTION
It was still pointing at 4.11. From this change on, the channel is
always going to be stable, so this is the last time this change is
required.
