### PR TITLE
Bug 2107558: Suggest metallb-system namespace

### DIFF
--- a/manifests/stable/metallb-operator.clusterserviceversion.yaml
+++ b/manifests/stable/metallb-operator.clusterserviceversion.yaml
@@ -278,6 +278,7 @@ metadata:
     description: An operator for deploying MetalLB on a kubernetes cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.8.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
+    operatorframework.io/suggested-namespace: metallb-system
     repository: https://github.com/openshift/metallb-operator
     support: Red Hat
   labels:


### PR DESCRIPTION
Now that the operator is cluster scoped, the web ui forces to install it
under the openshift-operators namespace. Here we set the annotation to
preserve the previously used ns "metallb-system".

Signed-off-by: Federico Paolinelli <fpaoline@redhat.com>