### PR TITLE
Openshift CVS: Add the spec to metallb

### DIFF
--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -219,7 +219,8 @@ metadata:
           "metadata": {
             "name": "metallb",
             "namespace": "metallb-system"
-          }
+          },
+          "spec": {}
         },
         {
           "apiVersion": "metallb.io/v1beta2",


### PR DESCRIPTION
CVP Ops is complaining about the spec missing from metallb:
"error spec does not exist for the custom resource metallb",
trying to fix that.
