### PR TITLE
OCP CI: add a bash script that runs validation against the bundle

### DIFF
--- a/hack/validate_ocp_bundle.sh
+++ b/hack/validate_ocp_bundle.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export OPERATOR_SDK_VERSION=v1.22.2
+make operator-sdk
+
+mkdir -p _cache/bundle/manifests
+cp manifests/stable/*.yaml _cache/bundle/manifests
+cp -r bundle/metadata _cache/bundle/
+operator-sdk bundle validate _cache/bundle


### PR DESCRIPTION
Here we add a script that runs operator-sdk bundle validate against our
csv (minus the metadata, taken from upstream).

Signed-off-by: Federico Paolinelli <fpaoline@redhat.com>