### PR TITLE
Bug 2100845: Enable webhook for l2advertisement

### DIFF
--- a/manifests/stable/metallb-operator.clusterserviceversion.yaml
+++ b/manifests/stable/metallb-operator.clusterserviceversion.yaml
@@ -1013,6 +1013,26 @@ spec:
       type: ValidatingAdmissionWebhook
       webhookPath: /validate-metallb-io-v1beta1-ipaddresspool
     - admissionReviewVersions:
+        - v1
+      containerPort: 443
+      deploymentName: metallb-operator-webhook-server
+      failurePolicy: Fail
+      generateName: l2advertisementvalidationwebhook.metallb.io
+      rules:
+        - apiGroups:
+            - metallb.io
+          apiVersions:
+            - v1beta1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - l2advertisements
+      sideEffects: None
+      targetPort: 9443
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-metallb-io-v1beta1-l2advertisement
+    - admissionReviewVersions:
         - v1alpha1
         - v1beta1
       containerPort: 443


### PR DESCRIPTION
This commit would enable validation webhook in the stable manifest csv
for l2advertisment crd as l2adv validation doesn't work on 4.12 deployment.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>