### PR TITLE
OCPBUGS-757: Extend the max asn number to match 4 bytes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,14 +164,7 @@ build-and-push-bundle-images: docker-build docker-push  ## Generate and push bun
 # download controller-gen if necessary
 controller-gen:
 ifeq (, $(shell which controller-gen))
-	@{ \
-	set -e ;\
-	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$CONTROLLER_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0 ;\
-	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
-	}
+	GOFLAGS="" go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)
@@ -179,14 +172,7 @@ endif
 
 kustomize:
 ifeq (, $(shell which kustomize))
-	@{ \
-	set -e ;\
-	KUSTOMIZE_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$KUSTOMIZE_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	go get sigs.k8s.io/kustomize/kustomize/v4@v4.4.0 ;\
-	rm -rf $$KUSTOMIZE_GEN_TMP_DIR ;\
-	}
+	GOFLAGS="" go install sigs.k8s.io/kustomize/kustomize/v4@latest
 KUSTOMIZE=$(GOBIN)/kustomize
 else
 KUSTOMIZE=$(shell which kustomize)

--- a/api/v1beta1/bgppeer_types.go
+++ b/api/v1beta1/bgppeer_types.go
@@ -39,12 +39,12 @@ type NodeSelector struct {
 type BGPPeerSpec struct {
 	// AS number to use for the local end of the session.
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=65535
+	// +kubebuilder:validation:Maximum=4294967295
 	MyASN uint32 `json:"myASN" yaml:"my-asn"`
 
 	// AS number to expect from the remote end of the session.
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=65535
+	// +kubebuilder:validation:Maximum=4294967295
 	ASN uint32 `json:"peerASN" yaml:"peer-asn"`
 
 	// Address to dial when establishing the session.

--- a/bin/metallb-operator-with-webhooks.yaml
+++ b/bin/metallb-operator-with-webhooks.yaml
@@ -329,7 +329,7 @@ spec:
               myASN:
                 description: AS number to use for the local end of the session.
                 format: int32
-                maximum: 65535
+                maximum: 4294967295
                 minimum: 0
                 type: integer
               nodeSelectors:
@@ -368,7 +368,7 @@ spec:
               peerASN:
                 description: AS number to expect from the remote end of the session.
                 format: int32
-                maximum: 65535
+                maximum: 4294967295
                 minimum: 0
                 type: integer
               peerAddress:

--- a/bin/metallb-operator.yaml
+++ b/bin/metallb-operator.yaml
@@ -329,7 +329,7 @@ spec:
               myASN:
                 description: AS number to use for the local end of the session.
                 format: int32
-                maximum: 65535
+                maximum: 4294967295
                 minimum: 0
                 type: integer
               nodeSelectors:
@@ -368,7 +368,7 @@ spec:
               peerASN:
                 description: AS number to expect from the remote end of the session.
                 format: int32
-                maximum: 65535
+                maximum: 4294967295
                 minimum: 0
                 type: integer
               peerAddress:

--- a/bundle/manifests/metallb.io_bgppeers.yaml
+++ b/bundle/manifests/metallb.io_bgppeers.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -48,7 +50,7 @@ spec:
               myASN:
                 description: AS number to use for the local end of the session.
                 format: int32
-                maximum: 65535
+                maximum: 4294967295
                 minimum: 0
                 type: integer
               nodeSelectors:
@@ -87,7 +89,7 @@ spec:
               peerASN:
                 description: AS number to expect from the remote end of the session.
                 format: int32
-                maximum: 65535
+                maximum: 4294967295
                 minimum: 0
                 type: integer
               peerAddress:

--- a/config/crd/bases/metallb.io_bgppeers.yaml
+++ b/config/crd/bases/metallb.io_bgppeers.yaml
@@ -50,7 +50,7 @@ spec:
               myASN:
                 description: AS number to use for the local end of the session.
                 format: int32
-                maximum: 65535
+                maximum: 4294967295
                 minimum: 0
                 type: integer
               nodeSelectors:
@@ -89,7 +89,7 @@ spec:
               peerASN:
                 description: AS number to expect from the remote end of the session.
                 format: int32
-                maximum: 65535
+                maximum: 4294967295
                 minimum: 0
                 type: integer
               peerAddress:

--- a/manifests/4.10/metallb.io_bgppeers.yaml
+++ b/manifests/4.10/metallb.io_bgppeers.yaml
@@ -48,7 +48,7 @@ spec:
               myASN:
                 description: AS number to use for the local end of the session.
                 format: int32
-                maximum: 65535
+                maximum: 4294967295
                 minimum: 0
                 type: integer
               nodeSelectors:
@@ -87,7 +87,7 @@ spec:
               peerASN:
                 description: AS number to expect from the remote end of the session.
                 format: int32
-                maximum: 65535
+                maximum: 4294967295
                 minimum: 0
                 type: integer
               peerAddress:


### PR DESCRIPTION
FRR supports 4 bytes asns, so we can extend the maximum.