### PR TITLE
fix naming convention

### DIFF
--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -4,7 +4,7 @@ updates:
     update_list:
     # replace metadata.name value
     - search: "metallb-operator.v{MAJOR}.{MINOR}.0"
-      replace: "metallb-operator.{FULL_VER}"
+      replace: "metallb-operator.v{FULL_VER}"
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
     - search: 'olm.skipRange: ">=4.8.0 <{MAJOR}.{MINOR}.0"'


### PR DESCRIPTION
there is a warning reported in CVP check for 4.12
`Warning: Value : (metallb-operator.4.12.0-202211081106) csv.metadata.Name metallb-operator.4.12.0-202211081106 is not following the recommended naming convention: <operator-name>.v<semver> e.g. memcached-operator.v0.0.1`
http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/ose-metallb-operator-bundle-container-v4.12.0.202211081106.p0.g400e854.assembly.stream-1/25722d11-444e-4b29-97ec-ae8252013758/operator-metadata-linting-bundle-image-output.txt
I think this could be a common issue, so pr against master can cherry-pick to 4.12 branch later.