### PR TITLE
OCPBUGS-6033: Helm: propagate the rbac image values to the charts

### DIFF
--- a/pkg/helm/config.go
+++ b/pkg/helm/config.go
@@ -109,6 +109,10 @@ func withPrometheusValues(c *chartConfig, valueMap map[string]interface{}) {
 				"tlsConfig":   controllerTLSConfig,
 			},
 		},
+		"rbacProxy": map[string]interface{}{
+			"repository": c.kubeRbacProxyImage.repo,
+			"tag":        c.kubeRbacProxyImage.tag,
+		},
 		"serviceAccount":             "foo", // required by the chart, we won't render roles or rolebindings anyway
 		"namespace":                  "bar",
 		"speakerMetricsTLSSecret":    speakerTLSSecret,

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -255,6 +255,7 @@ func TestParseSecureMetrics(t *testing.T) {
 		envVar{"HTTPS_METRICS_PORT", "9998"},
 		envVar{"FRR_HTTPS_METRICS_PORT", "9999"},
 		envVar{"METALLB_BGP_TYPE", "frr"},
+		envVar{"KUBE_RBAC_PROXY_IMAGE", "myrepo/image:mytag"},
 	)
 	g := NewGomegaWithT(t)
 	setEnv()

--- a/pkg/helm/testdata/vanilla-metrics-speaker.golden
+++ b/pkg/helm/testdata/vanilla-metrics-speaker.golden
@@ -268,7 +268,7 @@
                                 }
                             }
                         ],
-                        "image": "gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0",
+                        "image": "myrepo/image:mytag",
                         "imagePullPolicy": "IfNotPresent",
                         "name": "kube-rbac-proxy",
                         "ports": [
@@ -302,7 +302,7 @@
                                 }
                             }
                         ],
-                        "image": "gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0",
+                        "image": "myrepo/image:mytag",
                         "imagePullPolicy": "IfNotPresent",
                         "name": "kube-rbac-proxy-frr",
                         "ports": [


### PR DESCRIPTION
Despite reading the environment variable to set the image, we don't use it so the operator always deploy the default one.
