### PR TITLE
Add support label for s390x & ppc64le

### DIFF
--- a/manifests/stable/metallb-operator.clusterserviceversion.yaml
+++ b/manifests/stable/metallb-operator.clusterserviceversion.yaml
@@ -283,6 +283,8 @@ metadata:
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
   name: metallb-operator.v4.13.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
In order for the metallb-operator to be correctly filtered in the OperatorHub for s390x and ppc64le we need to add the correct arch label as supported.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>