### PR TITLE
OCPBUGS-11443: Controller metrics port: fix typo

### DIFF
--- a/bindata/deployment/openshift/metallb-openshift.yaml
+++ b/bindata/deployment/openshift/metallb-openshift.yaml
@@ -253,7 +253,7 @@ spec:
             - --logtostderr
             - --secure-listen-address=:{{.MetricsPortHttps}}
             - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-            - --upstream=http://127.0.0.1/{{.MetricsPort}}/
+            - --upstream=http://127.0.0.1:{{.MetricsPort}}/
             - --tls-private-key-file=/etc/metrics/tls.key
             - --tls-cert-file=/etc/metrics/tls.crt
           ports:


### PR DESCRIPTION
There was an error in the --upstream parameter that prevented the kuberbac proxy to expose the metrics of the controller pod correctly.