### PR TITLE
OCPBUGS-11861: Add loglevel configuration in metallb CR

### DIFF
--- a/bindata/deployment/frr/metallb-frr.yaml
+++ b/bindata/deployment/frr/metallb-frr.yaml
@@ -466,7 +466,7 @@ spec:
         - args:
             - --port={{.MetricsPort}}
             - --config=config
-            - --log-level=info
+            - --log-level={{.LogLevel}}
           env:
             - name: METALLB_ML_SECRET_NAME
               value: memberlist

--- a/bindata/deployment/native/metallb.yaml
+++ b/bindata/deployment/native/metallb.yaml
@@ -204,7 +204,7 @@ spec:
         - args:
             - --port=7472
             - --config=config
-            - --log-level=info
+            - --log-level={{.LogLevel}}
           env:
             - name: METALLB_ML_SECRET_NAME
               value: memberlist


### PR DESCRIPTION
Adding missing changes for the controller component, passing
down the LogLevel value from the CRD.