### PR TITLE
OCPBUGS-11861: Add log-level to ocp 4.10 manifests

### DIFF
--- a/manifests/4.10/metallb.io_metallbs.yaml
+++ b/manifests/4.10/metallb.io_metallbs.yaml
@@ -38,6 +38,18 @@ spec:
                 description: Foo is an example field of MetalLB. Edit MetalLB_types.go
                   to remove/update
                 type: string
+              logLevel:
+                  description: 'Define the verbosity of the controller and the speaker
+                    logging. Allowed values are: all, debug, info, warn, error, none.
+                    (default: info)'
+                  enum:
+                  - all
+                  - debug
+                  - info
+                  - warn
+                  - error
+                  - none
+                  type: string
               nodeSelector:
                 additionalProperties:
                   type: string


### PR DESCRIPTION
This commit adds the log-level field to the metallb crd in the 4.10 ocp manifests.