### PR TITLE
Add junit report configurations

### DIFF
--- a/test/e2e/functional/e2e_test.go
+++ b/test/e2e/functional/e2e_test.go
@@ -41,7 +41,11 @@ func TestE2E(t *testing.T) {
 
 	if *junitPath != "" {
 		junitFile := path.Join(*junitPath, "e2e_junit.xml")
-		reporterConfig.JUnitReport = junitFile
+		reporters.GenerateJUnitReportWithConfig(report, junitFile, reporters.JunitReportConfig{
+			OmitTimelinesForSpecState: types.SpecStatePassed | types.SpecStateSkipped,
+			OmitLeafNodeType:          true,
+			OmitSuiteSetupNodes:       true,
+		})
 	}
 
 	if *reportPath != "" {

--- a/test/e2e/validation/validation_test.go
+++ b/test/e2e/validation/validation_test.go
@@ -41,7 +41,11 @@ func TestValidation(t *testing.T) {
 
 	if *junitPath != "" {
 		junitFile := path.Join(*junitPath, "validation_junit.xml")
-		reporterConfig.JUnitReport = junitFile
+		reporters.GenerateJUnitReportWithConfig(report, junitFile, reporters.JunitReportConfig{
+			OmitTimelinesForSpecState: types.SpecStatePassed | types.SpecStateSkipped,
+			OmitLeafNodeType:          true,
+			OmitSuiteSetupNodes:       true,
+		})
 	}
 
 	if *reportPath != "" {


### PR DESCRIPTION
Modify the junit reporter to include configurations that are aligned with how we present and consume
the junit reports in the cnf-tests.

The confiurations omit from the reports the following:
1. Time lines for spec state. (for passed and skipped tests).
2. The leaf node type.
3. The suite setup nodes. (to prevent empty report entries).