### PR TITLE
Change the memberlist secret to contain path

### DIFF
--- a/bindata/deployment/frr/metallb-frr.yaml
+++ b/bindata/deployment/frr/metallb-frr.yaml
@@ -392,11 +392,8 @@ spec:
                   fieldPath: status.podIP
             - name: METALLB_ML_LABELS
               value: app=metallb,component=speaker
-            - name: METALLB_ML_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: secretkey
-                  name: memberlist
+            - name: METALLB_ML_SECRET_KEY_PATH
+              value: /etc/ml_secret_key
           image: '{{.SpeakerImage}}'
           livenessProbe:
             failureThreshold: 3
@@ -434,6 +431,9 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
           volumeMounts:
+            - mountPath: /etc/ml_secret_key
+              name: memberlist
+              readOnly: true
             - mountPath: /etc/frr_reloader
               name: reloader
           command:
@@ -547,6 +547,10 @@ spec:
           name: reloader
         - emptyDir: {}
           name: metrics
+        - name: memberlist
+          secret:
+            secretName: memberlist
+            defaultMode: 420
         {{ if .DeployKubeRbacProxies }}
         - name: speaker-certs
           secret:

--- a/bindata/deployment/native/metallb-native.yaml
+++ b/bindata/deployment/native/metallb-native.yaml
@@ -196,11 +196,8 @@ spec:
                   fieldPath: status.podIP
             - name: METALLB_ML_LABELS
               value: app=metallb,component=speaker
-            - name: METALLB_ML_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: secretkey
-                  name: memberlist
+            - name: METALLB_ML_SECRET_KEY_PATH
+              value: /etc/ml_secret_key
           image: '{{.SpeakerImage}}'
           livenessProbe:
             failureThreshold: 3
@@ -237,6 +234,10 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/ml_secret_key
+              name: memberlist
+              readOnly: true
           command:
             - /speaker
       hostNetwork: true
@@ -251,3 +252,8 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
           operator: Exists
+      volumes:
+        - name: memberlist
+          secret:
+            secretName: memberlist
+            defaultMode: 420

--- a/bindata/deployment/openshift/metallb-openshift.yaml
+++ b/bindata/deployment/openshift/metallb-openshift.yaml
@@ -336,6 +336,9 @@ spec:
               name: frr-sockets
             - mountPath: /etc/frr
               name: frr-conf
+            - mountPath: /etc/ml_secret_key
+              name: memberlist
+              readOnly: true
         - command:
             - /etc/frr_reloader/frr-reloader.sh
           image: '{{.FRRImage}}'
@@ -388,11 +391,8 @@ spec:
                   fieldPath: status.podIP
             - name: METALLB_ML_LABELS
               value: app=metallb,component=speaker
-            - name: METALLB_ML_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: secretkey
-                  name: memberlist
+            - name: METALLB_ML_SECRET_KEY_PATH
+              value: /etc/ml_secret_key
           image: '{{.SpeakerImage}}'
           livenessProbe:
             failureThreshold: 3
@@ -540,6 +540,10 @@ spec:
           name: reloader
         - emptyDir: {}
           name: metrics
+        - name: memberlist
+          secret:
+            secretName: memberlist
+            defaultMode: 420
         {{ if .DeployKubeRbacProxies }}
         - name: speaker-certs
           secret:


### PR DESCRIPTION
This is a backport from release 4.12, bringing the fix for the
memberlist secret.

Change the metallb's speaker yamls to mount the memberlist secret
into a VolumeMount, and change the METALLB_ML_SECRET_KEY var
to METALLB_ML_SECRET_KEY_PATH.

see #139 