### PR TITLE
OCPBUGS-14410: Add permissions to the speaker to read configmaps

### DIFF
--- a/manifests/stable/metallb-operator.clusterserviceversion.yaml
+++ b/manifests/stable/metallb-operator.clusterserviceversion.yaml
@@ -797,6 +797,14 @@ spec:
         serviceAccountName: default
       - rules:
         - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
             - ""
           resources:
             - pods


### PR DESCRIPTION
In order to process the extra frr config, the speaker must have read permissions.