### PR TITLE
OCPBUGS-14503: [4.10] Change the memberlist secret to contain path

### DIFF
--- a/bindata/deployment/frr/metallb-frr.yaml
+++ b/bindata/deployment/frr/metallb-frr.yaml
@@ -211,6 +211,10 @@ spec:
           emptyDir: {}
         - name: metrics
           emptyDir: {}
+        - name: memberlist
+          secret:
+            secretName: memberlist
+            defaultMode: 420
         {{ if .DeployKubeRbacProxies }}
         - name: speaker-certs
           secret:
@@ -331,16 +335,16 @@ spec:
             #  value: "7946"
             - name: METALLB_ML_LABELS
               value: "app=metallb,component=speaker"
-            - name: METALLB_ML_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: memberlist
-                  key: secretkey
+            - name: METALLB_ML_SECRET_KEY_PATH
+              value: /etc/ml_secret_key
           image: '{{.SpeakerImage}}'
           name: speaker
           volumeMounts:
             - name: reloader
               mountPath: /etc/frr_reloader
+            - name: memberlist
+              mountPath: /etc/ml_secret_key
+              readOnly: true
           ports:
             - containerPort: {{.MetricsPort}}
               name: monitoring

--- a/bindata/deployment/native/metallb.yaml
+++ b/bindata/deployment/native/metallb.yaml
@@ -124,11 +124,8 @@ spec:
             #  value: "7946"
             - name: METALLB_ML_LABELS
               value: "app=metallb,component=speaker"
-            - name: METALLB_ML_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: memberlist
-                  key: secretkey
+            - name: METALLB_ML_SECRET_KEY_PATH
+              value: /etc/ml_secret_key
           image: '{{.SpeakerImage}}'
           name: speaker
           ports:
@@ -167,6 +164,10 @@ spec:
             readOnlyRootFilesystem: true
           command:
             - /speaker
+          volumeMounts:
+            - mountPath: /etc/ml_secret_key
+              name: memberlist
+              readOnly: true
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
@@ -176,6 +177,11 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
           operator: Exists
+      volumes:
+          - name: memberlist
+            secret:
+              secretName: memberlist
+              defaultMode: 420
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This is a backport from release 4.11, bringing the fix for the memberlist secret.

Change the metallb's speaker yamls to mount the memberlist secret into a VolumeMount, and change the METALLB_ML_SECRET_KEY var to METALLB_ML_SECRET_KEY_PATH.

4.11 PRs:
https://github.com/openshift/metallb-operator/pull/162
and
https://github.com/openshift/metallb-operator/pull/165