### PR TITLE
OCPBUGS-14277: Fix ml_secret volumeMount location

### DIFF
--- a/bindata/deployment/openshift/metallb-openshift.yaml
+++ b/bindata/deployment/openshift/metallb-openshift.yaml
@@ -336,9 +336,6 @@ spec:
               name: frr-sockets
             - mountPath: /etc/frr
               name: frr-conf
-            - mountPath: /etc/ml_secret_key
-              name: memberlist
-              readOnly: true
         - command:
             - /etc/frr_reloader/frr-reloader.sh
           image: '{{.FRRImage}}'
@@ -432,6 +429,9 @@ spec:
           volumeMounts:
             - mountPath: /etc/frr_reloader
               name: reloader
+            - mountPath: /etc/ml_secret_key
+              name: memberlist
+              readOnly: true
           command:
             - /speaker
         {{ if .DeployKubeRbacProxies }}


### PR DESCRIPTION
This commit fixes a mistake in the implementation of the ml_secret fix for release 4.11, moving
the volumeMount from the FRR container to the speaker container, in the metallb-openshift.yaml file.