### PR TITLE
OCPBUGS-11824: Add the "support disconnected" infrastructure annotation

### DIFF
--- a/manifests/stable/metallb-operator.clusterserviceversion.yaml
+++ b/manifests/stable/metallb-operator.clusterserviceversion.yaml
@@ -279,6 +279,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.8.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     operatorframework.io/suggested-namespace: metallb-system
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/openshift/metallb-operator
     support: Red Hat
   labels:


### PR DESCRIPTION
As per the official docs, we add the annotation so it's documented that metallb can be mirrored.

https://docs.openshift.com/container-platform/4.11/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-manual-annotations_osdk-generating-csvs