### PR TITLE
OCPBUGS-14830: Remove the service account from the bundle as it's alredy in csv

### DIFF
--- a/bundle/manifests/manager-account_v1_serviceaccount.yaml
+++ b/bundle/manifests/manager-account_v1_serviceaccount.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  name: manager-account
-  namespace: metallb-system


### PR DESCRIPTION
This makes the bundle not valid.
