### PR TITLE
OCPBUGS-14830: Remove the service account file from manifests/stable

### DIFF
--- a/manifests/stable/manager-account_v1_serviceaccount.yaml
+++ b/manifests/stable/manager-account_v1_serviceaccount.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  name: manager-account
-  namespace: metallb-system


### PR DESCRIPTION
This makes the bundle validation fail