### PR TITLE
OCPBUGS-8433: [4.13] Fix metallb controller error log

### DIFF
--- a/controllers/metallb_controller.go
+++ b/controllers/metallb_controller.go
@@ -110,7 +110,7 @@ func (r *MetalLBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 		}
 		if err := status.Update(context.TODO(), r.Client, instance, condition, errorMsg, wrappedErrMsg); err != nil {
-			logger.Info("Failed to update metallb status", "Desired status", status.ConditionAvailable)
+			logger.Error(err, "Failed to update metallb status", "Desired status", status.ConditionAvailable)
 		}
 	}
 	return result, err

--- a/test/e2e/functional/tests/e2e.go
+++ b/test/e2e/functional/tests/e2e.go
@@ -68,7 +68,7 @@ var _ = Describe("metallb", func() {
 				Expect(daemonset.OwnerReferences).ToNot(BeNil())
 				Expect(daemonset.OwnerReferences[0].Kind).To(Equal("MetalLB"))
 
-				metallbutils.Delete(metallb)
+				metallbutils.DeleteAndCheck(metallb)
 			}
 		})
 
@@ -209,7 +209,7 @@ var _ = Describe("metallb", func() {
 
 			AfterEach(func() {
 				metallbutils.Delete(incorrect_metallb)
-				metallbutils.Delete(correct_metallb)
+				metallbutils.DeleteAndCheck(correct_metallb)
 			})
 			It("should have correct statuses", func() {
 				By("checking MetalLB resource status", func() {
@@ -261,7 +261,7 @@ var _ = Describe("metallb", func() {
 		})
 
 		AfterEach(func() {
-			metallbutils.Delete(correct_metallb)
+			metallbutils.DeleteAndCheck(correct_metallb)
 			metallbutils.DeletePriorityClass(priorityClass)
 		})
 
@@ -388,7 +388,7 @@ var _ = Describe("metallb", func() {
 					return nil
 				}, metallbutils.DeployTimeout, metallbutils.Interval).ShouldNot(HaveOccurred())
 
-				metallbutils.Delete(metallb)
+				metallbutils.DeleteAndCheck(metallb)
 			})
 		})
 	})
@@ -407,7 +407,7 @@ var _ = Describe("metallb", func() {
 		})
 
 		AfterEach(func() {
-			metallbutils.Delete(metallb)
+			metallbutils.DeleteAndCheck(metallb)
 			metallbutils.DeletePriorityClass(priorityClass)
 		})
 		It("patch additional parameters", func() {
@@ -557,7 +557,7 @@ var _ = Describe("metallb", func() {
 		})
 
 		AfterEach(func() {
-			metallbutils.Delete(correct_metallb)
+			metallbutils.DeleteAndCheck(correct_metallb)
 		})
 		It("validate create with incorrect toleration", func() {
 			metallb := metallbutils.New(OperatorNameSpace, func(m *metallbv1beta1.MetalLB) {
@@ -634,7 +634,7 @@ var _ = Describe("metallb", func() {
 				}
 			})
 			Expect(testclient.Client.Create(context.Background(), metallb)).Should(Succeed())
-			metallbutils.Delete(metallb)
+			metallbutils.DeleteAndCheck(metallb)
 			metallb = metallbutils.New(OperatorNameSpace, func(m *metallbv1beta1.MetalLB) {
 				m.Spec.SpeakerConfig = &metallbv1beta1.Config{
 					Affinity: &v1.Affinity{NodeAffinity: &v1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{

--- a/test/e2e/metallb/metallb.go
+++ b/test/e2e/metallb/metallb.go
@@ -36,6 +36,10 @@ func Delete(metallb *metallbv1beta1.MetalLB) {
 		return
 	}
 	Expect(err).ToNot(HaveOccurred())
+}
+
+func DeleteAndCheck(metallb *metallbv1beta1.MetalLB) {
+	Delete(metallb)
 
 	Eventually(func() bool {
 		err := testclient.Client.Get(context.Background(), goclient.ObjectKey{Namespace: metallb.Namespace, Name: metallb.Name}, metallb)


### PR DESCRIPTION
This PR cherry-picks 2 commits that fix the metallb controller to print the content of the error in the log, plus
fixing the cleanup order in the e2etests.

This PR references a bug concerning a flaky test case titled:
`Correct and incorrect MetalLB resources coexist should have correct statuses`