### PR TITLE
[release-4.12] OCPBUGS-15771: Fix metallb controller condition reason string

### DIFF
--- a/controllers/metallb_controller.go
+++ b/controllers/metallb_controller.go
@@ -102,8 +102,9 @@ func (r *MetalLBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	result, condition, err := r.reconcileResource(ctx, req, instance)
 	if condition != "" {
-		errorMsg, wrappedErrMsg := "", ""
+		errorMsg, wrappedErrMsg := condition, ""
 		if err != nil {
+			errorMsg = err.Error()
 			if errors.Unwrap(err) != nil {
 				wrappedErrMsg = errors.Unwrap(err).Error()
 			}


### PR DESCRIPTION
This commit brings a fix to the metallb controller that is missing from 4.12, 4.11.

The fix:
The Reason string in Condition object can't be empty and must have atleast one character. so use condition string when it's empty.