### PR TITLE
[release-4.13] OCPBUGS-8433: Fix flake MetalLB resources should have correct statuses

### DIFF
--- a/controllers/metallb_controller.go
+++ b/controllers/metallb_controller.go
@@ -110,7 +110,7 @@ func (r *MetalLBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 		}
 		if err := status.Update(context.TODO(), r.Client, instance, condition, errorMsg, wrappedErrMsg); err != nil {
-			logger.Error(err, "Failed to update metallb status", "Desired status", status.ConditionAvailable)
+			logger.Error(err, "Failed to update metallb status", "Desired status", condition)
 		}
 	}
 	return result, err

--- a/controllers/metallb_controller.go
+++ b/controllers/metallb_controller.go
@@ -106,7 +106,7 @@ func (r *MetalLBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if condition != "" {
 		errorMsg, wrappedErrMsg := condition, ""
 		if err != nil {
-			errorMsg = err.Error()
+			errorMsg = "internal error"
 			if errors.Unwrap(err) != nil {
 				wrappedErrMsg = errors.Unwrap(err).Error()
 			}

--- a/controllers/metallb_controller.go
+++ b/controllers/metallb_controller.go
@@ -96,7 +96,9 @@ func (r *MetalLBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		logger.Error(err, "Invalid MetalLB resource name", "name", req.Name)
 		if err := status.Update(context.TODO(), r.Client, instance, status.ConditionDegraded, "IncorrectMetalLBResourceName", fmt.Sprintf("Incorrect MetalLB resource name: %s", req.Name)); err != nil {
 			logger.Error(err, "Failed to update metallb status", "Desired status", status.ConditionDegraded)
+			return ctrl.Result{}, nil // Return success to avoid requeue
 		}
+		logger.Info("updated metallb status successfully", "condition", status.ConditionDegraded, "resource name", req.Name)
 		return ctrl.Result{}, nil // Return success to avoid requeue
 	}
 
@@ -111,9 +113,11 @@ func (r *MetalLBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		if err := status.Update(context.TODO(), r.Client, instance, condition, errorMsg, wrappedErrMsg); err != nil {
 			logger.Error(err, "Failed to update metallb status", "Desired status", condition)
+			return ctrl.Result{}, err
 		}
+		logger.Info("updated metallb status successfully", "condition", condition, "resource name", req.Name)
 	}
-	return result, err
+	return result, nil
 }
 
 func (r *MetalLBReconciler) reconcileResource(ctx context.Context, req ctrl.Request, instance *metallbv1beta1.MetalLB) (ctrl.Result, string, error) {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -101,7 +101,7 @@ func IsMetalLBAvailable(ctx context.Context, client k8sclient.Client, namespace 
 	if err != nil {
 		return err
 	}
-	if ds.Status.DesiredNumberScheduled != ds.Status.CurrentNumberScheduled {
+	if ds.Status.DesiredNumberScheduled != ds.Status.CurrentNumberScheduled || ds.Status.DesiredNumberScheduled != ds.Status.NumberReady {
 		return MetalLBResourcesNotReadyError{Message: "MetalLB speaker daemonset not ready"}
 	}
 	deployment := &appsv1.Deployment{}

--- a/test/e2e/functional/tests/e2e.go
+++ b/test/e2e/functional/tests/e2e.go
@@ -13,6 +13,7 @@ import (
 	"github.com/metallb/metallb-operator/pkg/status"
 	"github.com/metallb/metallb-operator/test/consts"
 	testclient "github.com/metallb/metallb-operator/test/e2e/client"
+	"github.com/metallb/metallb-operator/test/e2e/metallb"
 	metallbutils "github.com/metallb/metallb-operator/test/e2e/metallb"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -225,7 +226,7 @@ var _ = Describe("metallb", func() {
 						err := testclient.Client.Get(context.TODO(), goclient.ObjectKey{Namespace: correct_metallb.Namespace, Name: correct_metallb.Name}, instance)
 						Expect(err).ToNot(HaveOccurred())
 						return metallbutils.CheckConditionStatus(instance) == status.ConditionAvailable
-					}, 30*time.Second, 5*time.Second).Should(BeTrue())
+					}, metallb.DeployTimeout, 5*time.Second).Should(BeTrue())
 
 					// Delete incorrectly named resource
 					err := testclient.Client.Delete(context.Background(), incorrect_metallb)


### PR DESCRIPTION
cherry-pick of: https://github.com/openshift/metallb-operator/pull/178

Note: 
- The fix for the flake is in the commit: "Use the DeployTimeout const in e2etest".
- The other commits are different improvements that were add together with the fix,
  that makes sense to include them here as well.
- The commit "Update kind's node image" was omitted deliberately.