### PR TITLE
OCPBUGS-18838: Backport liveness 4.12

### DIFF
--- a/.github/workflows/metallb_e2e.yml
+++ b/.github/workflows/metallb_e2e.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           repository: metallb/metallb
           path: metallb
-          ref: 4b236c70e03c6bc1ae7227e404f561fb159601ee
+          ref: 87842bdc6e0e42754f93ecccef2bcdac596ccd06
       - name: Checkout MetalLB v0.12.1
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/metallb_e2e.yml
+++ b/.github/workflows/metallb_e2e.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           repository: metallb/metallb
           path: metallb
-          ref: fb96318bb4d01495098c3ee122f896b67cf9b177
+          ref: 4b236c70e03c6bc1ae7227e404f561fb159601ee
       - name: Checkout MetalLB v0.12.1
         uses: actions/checkout@v2
         with:
@@ -59,7 +59,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install python3-pip arping ndisc6
+          sudo apt-get install linux-modules-extra-$(uname -r) python3-pip arping ndisc6
           sudo pip3 install -r ${GITHUB_WORKSPACE}/metallb/dev-env/requirements.txt
       - name: Build image
         run: |

--- a/bin/metallb-operator.yaml
+++ b/bin/metallb-operator.yaml
@@ -233,7 +233,20 @@ spec:
     singular: bfdprofile
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.passiveMode
+      name: Passive Mode
+      type: boolean
+    - jsonPath: .spec.transmitInterval
+      name: Transmit Interval
+      type: integer
+    - jsonPath: .spec.receiveInterval
+      name: Receive Interval
+      type: integer
+    - jsonPath: .spec.detectMultiplier
+      name: Multiplier
+      type: integer
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: BFDProfile represents the settings of the bfd session that can
@@ -333,7 +346,21 @@ spec:
     singular: bgpadvertisement
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.ipAddressPools
+      name: IPAddressPools
+      type: string
+    - jsonPath: .spec.ipAddressPoolSelectors
+      name: IPAddressPool Selectors
+      type: string
+    - jsonPath: .spec.peers
+      name: Peers
+      type: string
+    - jsonPath: .spec.nodeSelectors
+      name: Node Selectors
+      priority: 10
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: BGPAdvertisement allows to advertise the IPs coming from the
@@ -542,7 +569,20 @@ spec:
     singular: bgppeer
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.peerAddress
+      name: Address
+      type: string
+    - jsonPath: .spec.peerASN
+      name: ASN
+      type: string
+    - jsonPath: .spec.bfdProfile
+      name: BFD Profile
+      type: string
+    - jsonPath: .spec.ebgpMultiHop
+      name: Multi Hops
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: BGPPeer is the Schema for the peers API.
@@ -645,7 +685,20 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta2
+  - additionalPrinterColumns:
+    - jsonPath: .spec.peerAddress
+      name: Address
+      type: string
+    - jsonPath: .spec.peerASN
+      name: ASN
+      type: string
+    - jsonPath: .spec.bfdProfile
+      name: BFD Profile
+      type: string
+    - jsonPath: .spec.ebgpMultiHop
+      name: Multi Hops
+      type: string
+    name: v1beta2
     schema:
       openAPIV3Schema:
         description: BGPPeer is the Schema for the peers API.
@@ -878,7 +931,17 @@ spec:
     singular: ipaddresspool
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.autoAssign
+      name: Auto Assign
+      type: boolean
+    - jsonPath: .spec.avoidBuggyIPs
+      name: Avoid Buggy IPs
+      type: boolean
+    - jsonPath: .spec.addresses
+      name: Addresses
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: IPAddressPool represents a pool of IP addresses that can be allocated
@@ -953,7 +1016,21 @@ spec:
     singular: l2advertisement
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.ipAddressPools
+      name: IPAddressPools
+      type: string
+    - jsonPath: .spec.ipAddressPoolSelectors
+      name: IPAddressPool Selectors
+      type: string
+    - jsonPath: .spec.interfaces
+      name: Interfaces
+      type: string
+    - jsonPath: .spec.nodeSelectors
+      name: Node Selectors
+      priority: 10
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: L2Advertisement allows to advertise the LoadBalancer IPs provided

--- a/bin/metallb-operator.yaml
+++ b/bin/metallb-operator.yaml
@@ -3999,6 +3999,7 @@ rules:
   - ""
   resources:
   - services
+  - namespaces
   verbs:
   - get
   - list
@@ -4063,6 +4064,7 @@ rules:
   - services
   - endpoints
   - nodes
+  - namespaces
   verbs:
   - get
   - list

--- a/bindata/deployment/helm/README.md
+++ b/bindata/deployment/helm/README.md
@@ -52,6 +52,7 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | controller.strategy.type | string | `"RollingUpdate"` |  |
 | controller.tolerations | list | `[]` |  |
 | crds.enabled | bool | `true` |  |
+| crds.validationFailurePolicy | string | `"Fail"` |  |
 | fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | loadBalancerClass | string | `""` |  |
@@ -85,6 +86,7 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | prometheus.prometheusRule.extraAlerts | list | `[]` |  |
 | prometheus.prometheusRule.staleConfig.enabled | bool | `true` |  |
 | prometheus.prometheusRule.staleConfig.labels.severity | string | `"warning"` |  |
+| prometheus.rbacPrometheus | bool | `true` |  |
 | prometheus.rbacProxy.repository | string | `"gcr.io/kubebuilder/kube-rbac-proxy"` |  |
 | prometheus.rbacProxy.tag | string | `"v0.12.0"` |  |
 | prometheus.scrapeAnnotations | bool | `false` |  |
@@ -109,6 +111,8 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | speaker.frr.image.repository | string | `"frrouting/frr"` |  |
 | speaker.frr.image.tag | string | `"v7.5.1"` |  |
 | speaker.frr.metricsPort | int | `7473` |  |
+| speaker.frr.resources | object | `{}` |  |
+| speaker.frrMetrics.resources | object | `{}` |  |
 | speaker.image.pullPolicy | string | `nil` |  |
 | speaker.image.repository | string | `"quay.io/metallb/speaker"` |  |
 | speaker.image.tag | string | `nil` |  |
@@ -131,6 +135,7 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | speaker.readinessProbe.periodSeconds | int | `10` |  |
 | speaker.readinessProbe.successThreshold | int | `1` |  |
 | speaker.readinessProbe.timeoutSeconds | int | `1` |  |
+| speaker.reloader.resources | object | `{}` |  |
 | speaker.resources | object | `{}` |  |
 | speaker.runtimeClassName | string | `""` |  |
 | speaker.serviceAccount.annotations | object | `{}` |  |

--- a/bindata/deployment/helm/README.md
+++ b/bindata/deployment/helm/README.md
@@ -141,6 +141,9 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | speaker.serviceAccount.annotations | object | `{}` |  |
 | speaker.serviceAccount.create | bool | `true` |  |
 | speaker.serviceAccount.name | string | `""` |  |
+| speaker.startupProbe.enabled | bool | `true` |  |
+| speaker.startupProbe.failureThreshold | int | `30` |  |
+| speaker.startupProbe.periodSeconds | int | `5` |  |
 | speaker.tolerateMaster | bool | `true` |  |
 | speaker.tolerations | list | `[]` |  |
 | speaker.updateStrategy.type | string | `"RollingUpdate"` |  |

--- a/bindata/deployment/helm/templates/podmonitor.yaml
+++ b/bindata/deployment/helm/templates/podmonitor.yaml
@@ -75,6 +75,7 @@ spec:
 {{- toYaml .Values.prometheus.podMonitor.relabelings | nindent 4 }}
 {{- end }}
 ---
+{{- if .Values.prometheus.rbacPrometheus }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -101,4 +102,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ required ".Values.prometheus.serviceAccount must be defined when .Values.prometheus.podMonitor.enabled == true" .Values.prometheus.serviceAccount }}
     namespace: {{ required ".Values.prometheus.namespace must be defined when .Values.prometheus.podMonitor.enabled == true" .Values.prometheus.namespace }}
+{{- end }}
 {{- end }}

--- a/bindata/deployment/helm/templates/servicemonitor.yaml
+++ b/bindata/deployment/helm/templates/servicemonitor.yaml
@@ -17,9 +17,17 @@ spec:
   endpoints:
     - port: {{ template "metrics.exposedportname" . }}
       honorLabels: true
+      {{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+      {{- toYaml .Values.prometheus.serviceMonitor.metricRelabelings | nindent 8 }}
+      {{- end -}}
+      {{- if .Values.prometheus.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml .Values.prometheus.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
       {{- if .Values.prometheus.serviceMonitor.interval }}
       interval: {{ .Values.prometheus.serviceMonitor.interval }}
-      {{- end }}
+      {{- end -}}
 {{ if .Values.prometheus.secureMetricsPort }}
       bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
       scheme: "https"
@@ -155,6 +163,7 @@ spec:
   sessionAffinity: None
   type: ClusterIP
 ---
+{{- if .Values.prometheus.rbacPrometheus }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -183,4 +192,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ required ".Values.prometheus.serviceAccount must be defined when .Values.prometheus.serviceMonitor.enabled == true" .Values.prometheus.serviceAccount }}
     namespace: {{ required ".Values.prometheus.namespace must be defined when .Values.prometheus.serviceMonitor.enabled == true" .Values.prometheus.namespace }}
-{{ end }}
+{{- end }}
+{{- end }}

--- a/bindata/deployment/helm/templates/speaker.yaml
+++ b/bindata/deployment/helm/templates/speaker.yaml
@@ -165,8 +165,6 @@ spec:
           emptyDir: {}
         - name: metrics
           emptyDir: {}
-        - name: frr-liveness
-          emptyDir: {}
       {{- if .Values.prometheus.speakerMetricsTLSSecret }}
         - name: metrics-certs
           secret:
@@ -192,13 +190,6 @@ spec:
           volumeMounts:
             - name: reloader
               mountPath: /etc/frr_reloader
-        # Copies the liveness probe script to the shared volume between the speaker and reloader.
-        - name: cp-liveness
-          image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
-          command: ["/bin/sh", "-c", "cp -f /liveness.sh /etc/frr_liveness/"]
-          volumeMounts:
-            - name: frr-liveness
-              mountPath: /etc/frr_liveness
         # Copies the metrics exporter
         - name: cp-metrics
           image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
@@ -332,8 +323,6 @@ spec:
             mountPath: /var/run/frr
           - name: frr-conf
             mountPath: /etc/frr
-          - name: frr-liveness
-            mountPath: /etc/frr_liveness
         # The command is FRR's default entrypoint & waiting for the log file to appear and tailing it.
         # If the log file isn't created in 60 seconds the tail fails and the container is restarted.
         # This workaround is needed to have the frr logs as part of kubectl logs -c frr < speaker_pod_name >.
@@ -352,16 +341,22 @@ spec:
         resources:
           {{- toYaml . | nindent 12 }}
         {{- end }}
+        {{- if .Values.speaker.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command: ["/etc/frr_liveness/liveness.sh"]
-          periodSeconds: 5
-          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: {{ .Values.speaker.frr.metricsPort }}
+          periodSeconds: {{ .Values.speaker.livenessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.speaker.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.speaker.startupProbe.enabled }}
         startupProbe:
-          exec:
-            command: ["/etc/frr_liveness/liveness.sh"]
-          failureThreshold: 30
-          periodSeconds: 5
+          httpGet:
+            path: /livez
+            port: {{ .Values.speaker.frr.metricsPort }}
+          failureThreshold: {{ .Values.speaker.startupProbe.failureThreshold }}
+          periodSeconds: {{ .Values.speaker.startupProbe.periodSeconds }}
+        {{- end }}
       - name: reloader
         image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
         {{- if .Values.speaker.frr.image.pullPolicy }}

--- a/bindata/deployment/helm/templates/speaker.yaml
+++ b/bindata/deployment/helm/templates/speaker.yaml
@@ -165,6 +165,8 @@ spec:
           emptyDir: {}
         - name: metrics
           emptyDir: {}
+        - name: frr-liveness
+          emptyDir: {}
       {{- if .Values.prometheus.speakerMetricsTLSSecret }}
         - name: metrics-certs
           secret:
@@ -190,6 +192,13 @@ spec:
           volumeMounts:
             - name: reloader
               mountPath: /etc/frr_reloader
+        # Copies the liveness probe script to the shared volume between the speaker and reloader.
+        - name: cp-liveness
+          image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
+          command: ["/bin/sh", "-c", "cp -f /liveness.sh /etc/frr_liveness/"]
+          volumeMounts:
+            - name: frr-liveness
+              mountPath: /etc/frr_liveness
         # Copies the metrics exporter
         - name: cp-metrics
           image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
@@ -323,6 +332,8 @@ spec:
             mountPath: /var/run/frr
           - name: frr-conf
             mountPath: /etc/frr
+          - name: frr-liveness
+            mountPath: /etc/frr_liveness
         # The command is FRR's default entrypoint & waiting for the log file to appear and tailing it.
         # If the log file isn't created in 60 seconds the tail fails and the container is restarted.
         # This workaround is needed to have the frr logs as part of kubectl logs -c frr < speaker_pod_name >.
@@ -341,6 +352,16 @@ spec:
         resources:
           {{- toYaml . | nindent 12 }}
         {{- end }}
+        livenessProbe:
+          exec:
+            command: ["/etc/frr_liveness/liveness.sh"]
+          periodSeconds: 5
+          failureThreshold: 3
+        startupProbe:
+          exec:
+            command: ["/etc/frr_liveness/liveness.sh"]
+          failureThreshold: 30
+          periodSeconds: 5
       - name: reloader
         image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
         {{- if .Values.speaker.frr.image.pullPolicy }}

--- a/bindata/deployment/helm/templates/speaker.yaml
+++ b/bindata/deployment/helm/templates/speaker.yaml
@@ -337,6 +337,10 @@ spec:
               attempts=$(( $attempts + 1 ))
             done
             tail -f /etc/frr/frr.log
+        {{- with .Values.speaker.frr.resources }}
+        resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
       - name: reloader
         image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
         {{- if .Values.speaker.frr.image.pullPolicy }}
@@ -350,6 +354,10 @@ spec:
             mountPath: /etc/frr
           - name: reloader
             mountPath: /etc/frr_reloader
+        {{- with .Values.speaker.reloader.resources }}
+        resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
       - name: frr-metrics
         image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
         command: ["/etc/frr_metrics/frr-metrics"]
@@ -365,6 +373,10 @@ spec:
             mountPath: /etc/frr
           - name: metrics
             mountPath: /etc/frr_metrics
+        {{- with .Values.speaker.frrMetrics.resources }}
+        resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
       {{- end }}
       {{- if .Values.prometheus.secureMetricsPort }}
       - name: kube-rbac-proxy

--- a/bindata/deployment/helm/values.schema.json
+++ b/bindata/deployment/helm/values.schema.json
@@ -179,6 +179,7 @@
         "scrapeAnnotations": { "type": "boolean" },
         "metricsPort": { "type": "integer" },
         "secureMetricsPort": { "type": "integer" },
+        "rbacPrometheus": { "type": "boolean" },
         "serviceAccount": { "type": "string" },
         "namespace": { "type": "string" },
         "rbacProxy": {
@@ -345,17 +346,45 @@
                 },
                 "image": { "$ref": "#/definitions/component/properties/image" },
                 "metricsPort": { "type": "integer" },
-                "secureMetricsPort": { "type": "integer" }
+                "secureMetricsPort": { "type": "integer" },
+                "resources:": { "type": "object" }
               },
               "required": [ "enabled" ]
             },
             "command" : {
               "type": "string"
+            },
+            "reloader": {
+              "type": "object",
+              "properties": {
+                "resources": { "type": "object" }
+              }
+            },
+            "frrMetrics": {
+              "type": "object",
+              "properties": {
+                "resources": { "type": "object" }
+              }
             }
           },
           "required": [ "tolerateMaster" ]
         }
       ]
+    },
+    "crds": {
+      "description": "CRD configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable CRDs",
+          "type": "boolean"
+        },
+        "validationFailurePolicy": {
+          "description": "Failure policy to use with validating webhooks",
+          "type": "string",
+          "enum": [ "Ignore", "Fail" ]
+        }
+      }
     }
   },
   "controller": { 

--- a/bindata/deployment/helm/values.yaml
+++ b/bindata/deployment/helm/values.yaml
@@ -307,6 +307,10 @@ speaker:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
+  startupProbe:
+    enabled: true
+    failureThreshold: 30
+    periodSeconds: 5
   # frr contains configuration specific to the MetalLB FRR container,
   # for speaker running alongside FRR.
   frr:

--- a/bindata/deployment/helm/values.yaml
+++ b/bindata/deployment/helm/values.yaml
@@ -42,12 +42,15 @@ prometheus:
   # certificate to be used.
   controllerMetricsTLSSecret: ""
 
+  # prometheus doens't have the permission to scrape all namespaces so we give it permission to scrape metallb's one
+  rbacPrometheus: true
+
   # the service account used by prometheus
-  # required when .Values.prometheus.podMonitor.enabled == true
+  # required when " .Values.prometheus.rbacPrometheus == true " and " .Values.prometheus.podMonitor.enabled=true or prometheus.serviceMonitor.enabled=true "
   serviceAccount: ""
 
   # the namespace where prometheus is deployed
-  # required when .Values.prometheus.podMonitor.enabled == true
+  # required when " .Values.prometheus.rbacPrometheus == true " and " .Values.prometheus.podMonitor.enabled=true or prometheus.serviceMonitor.enabled=true "
   namespace: ""
 
   # the image to be used for the kuberbacproxy container
@@ -313,10 +316,18 @@ speaker:
       tag: v7.5.1
       pullPolicy:
     metricsPort: 7473
+    resources: {}
 
     # if set, enables a rbac proxy sidecar container on the speaker to
     # expose the frr metrics via tls.
     # secureMetricsPort: 9121
 
+  reloader:
+    resources: {}
+
+  frrMetrics:
+    resources: {}
+
 crds:
   enabled: true
+  validationFailurePolicy: Fail

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -343,6 +343,7 @@ spec:
                 - ""
               resources:
                 - services
+                - namespaces
               verbs:
                 - get
                 - list
@@ -512,6 +513,7 @@ spec:
                 - services
                 - endpoints
                 - nodes
+                - namespaces
               verbs:
                 - get
                 - list

--- a/bundle/manifests/metallb.io_bfdprofiles.yaml
+++ b/bundle/manifests/metallb.io_bfdprofiles.yaml
@@ -14,7 +14,20 @@ spec:
     singular: bfdprofile
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.passiveMode
+      name: Passive Mode
+      type: boolean
+    - jsonPath: .spec.transmitInterval
+      name: Transmit Interval
+      type: integer
+    - jsonPath: .spec.receiveInterval
+      name: Receive Interval
+      type: integer
+    - jsonPath: .spec.detectMultiplier
+      name: Multiplier
+      type: integer
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: BFDProfile represents the settings of the bfd session that can

--- a/bundle/manifests/metallb.io_bgpadvertisements.yaml
+++ b/bundle/manifests/metallb.io_bgpadvertisements.yaml
@@ -14,7 +14,21 @@ spec:
     singular: bgpadvertisement
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.ipAddressPools
+      name: IPAddressPools
+      type: string
+    - jsonPath: .spec.ipAddressPoolSelectors
+      name: IPAddressPool Selectors
+      type: string
+    - jsonPath: .spec.peers
+      name: Peers
+      type: string
+    - jsonPath: .spec.nodeSelectors
+      name: Node Selectors
+      priority: 10
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: BGPAdvertisement allows to advertise the IPs coming from the

--- a/bundle/manifests/metallb.io_bgppeers.yaml
+++ b/bundle/manifests/metallb.io_bgppeers.yaml
@@ -26,7 +26,20 @@ spec:
     singular: bgppeer
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.peerAddress
+      name: Address
+      type: string
+    - jsonPath: .spec.peerASN
+      name: ASN
+      type: string
+    - jsonPath: .spec.bfdProfile
+      name: BFD Profile
+      type: string
+    - jsonPath: .spec.ebgpMultiHop
+      name: Multi Hops
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: BGPPeer is the Schema for the peers API.
@@ -129,7 +142,20 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta2
+  - additionalPrinterColumns:
+    - jsonPath: .spec.peerAddress
+      name: Address
+      type: string
+    - jsonPath: .spec.peerASN
+      name: ASN
+      type: string
+    - jsonPath: .spec.bfdProfile
+      name: BFD Profile
+      type: string
+    - jsonPath: .spec.ebgpMultiHop
+      name: Multi Hops
+      type: string
+    name: v1beta2
     schema:
       openAPIV3Schema:
         description: BGPPeer is the Schema for the peers API.

--- a/bundle/manifests/metallb.io_ipaddresspools.yaml
+++ b/bundle/manifests/metallb.io_ipaddresspools.yaml
@@ -14,7 +14,17 @@ spec:
     singular: ipaddresspool
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.autoAssign
+      name: Auto Assign
+      type: boolean
+    - jsonPath: .spec.avoidBuggyIPs
+      name: Avoid Buggy IPs
+      type: boolean
+    - jsonPath: .spec.addresses
+      name: Addresses
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: IPAddressPool represents a pool of IP addresses that can be allocated

--- a/bundle/manifests/metallb.io_l2advertisements.yaml
+++ b/bundle/manifests/metallb.io_l2advertisements.yaml
@@ -14,7 +14,21 @@ spec:
     singular: l2advertisement
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.ipAddressPools
+      name: IPAddressPools
+      type: string
+    - jsonPath: .spec.ipAddressPoolSelectors
+      name: IPAddressPool Selectors
+      type: string
+    - jsonPath: .spec.interfaces
+      name: Interfaces
+      type: string
+    - jsonPath: .spec.nodeSelectors
+      name: Node Selectors
+      priority: 10
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: L2Advertisement allows to advertise the LoadBalancer IPs provided

--- a/config/crd/bases/metallb.io_bfdprofiles.yaml
+++ b/config/crd/bases/metallb.io_bfdprofiles.yaml
@@ -14,7 +14,20 @@ spec:
     singular: bfdprofile
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.passiveMode
+      name: Passive Mode
+      type: boolean
+    - jsonPath: .spec.transmitInterval
+      name: Transmit Interval
+      type: integer
+    - jsonPath: .spec.receiveInterval
+      name: Receive Interval
+      type: integer
+    - jsonPath: .spec.detectMultiplier
+      name: Multiplier
+      type: integer
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: BFDProfile represents the settings of the bfd session that can

--- a/config/crd/bases/metallb.io_bgpadvertisements.yaml
+++ b/config/crd/bases/metallb.io_bgpadvertisements.yaml
@@ -14,7 +14,21 @@ spec:
     singular: bgpadvertisement
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.ipAddressPools
+      name: IPAddressPools
+      type: string
+    - jsonPath: .spec.ipAddressPoolSelectors
+      name: IPAddressPool Selectors
+      type: string
+    - jsonPath: .spec.peers
+      name: Peers
+      type: string
+    - jsonPath: .spec.nodeSelectors
+      name: Node Selectors
+      priority: 10
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: BGPAdvertisement allows to advertise the IPs coming from the

--- a/config/crd/bases/metallb.io_bgppeers.yaml
+++ b/config/crd/bases/metallb.io_bgppeers.yaml
@@ -14,7 +14,20 @@ spec:
     singular: bgppeer
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.peerAddress
+      name: Address
+      type: string
+    - jsonPath: .spec.peerASN
+      name: ASN
+      type: string
+    - jsonPath: .spec.bfdProfile
+      name: BFD Profile
+      type: string
+    - jsonPath: .spec.ebgpMultiHop
+      name: Multi Hops
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: BGPPeer is the Schema for the peers API.
@@ -117,7 +130,20 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta2
+  - additionalPrinterColumns:
+    - jsonPath: .spec.peerAddress
+      name: Address
+      type: string
+    - jsonPath: .spec.peerASN
+      name: ASN
+      type: string
+    - jsonPath: .spec.bfdProfile
+      name: BFD Profile
+      type: string
+    - jsonPath: .spec.ebgpMultiHop
+      name: Multi Hops
+      type: string
+    name: v1beta2
     schema:
       openAPIV3Schema:
         description: BGPPeer is the Schema for the peers API.

--- a/config/crd/bases/metallb.io_ipaddresspools.yaml
+++ b/config/crd/bases/metallb.io_ipaddresspools.yaml
@@ -14,7 +14,17 @@ spec:
     singular: ipaddresspool
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.autoAssign
+      name: Auto Assign
+      type: boolean
+    - jsonPath: .spec.avoidBuggyIPs
+      name: Avoid Buggy IPs
+      type: boolean
+    - jsonPath: .spec.addresses
+      name: Addresses
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: IPAddressPool represents a pool of IP addresses that can be allocated

--- a/config/crd/bases/metallb.io_l2advertisements.yaml
+++ b/config/crd/bases/metallb.io_l2advertisements.yaml
@@ -14,7 +14,21 @@ spec:
     singular: l2advertisement
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.ipAddressPools
+      name: IPAddressPools
+      type: string
+    - jsonPath: .spec.ipAddressPoolSelectors
+      name: IPAddressPool Selectors
+      type: string
+    - jsonPath: .spec.interfaces
+      name: Interfaces
+      type: string
+    - jsonPath: .spec.nodeSelectors
+      name: Node Selectors
+      priority: 10
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: L2Advertisement allows to advertise the LoadBalancer IPs provided

--- a/config/metallb_rbac/metallb-frr.yaml
+++ b/config/metallb_rbac/metallb-frr.yaml
@@ -196,6 +196,7 @@ rules:
       - ""
     resources:
       - services
+      - namespaces
     verbs:
       - get
       - list
@@ -260,6 +261,7 @@ rules:
       - services
       - endpoints
       - nodes
+      - namespaces
     verbs:
       - get
       - list

--- a/config/metallb_rbac/metallb-native.yaml
+++ b/config/metallb_rbac/metallb-native.yaml
@@ -196,6 +196,7 @@ rules:
       - ""
     resources:
       - services
+      - namespaces
     verbs:
       - get
       - list
@@ -260,6 +261,7 @@ rules:
       - services
       - endpoints
       - nodes
+      - namespaces
     verbs:
       - get
       - list

--- a/config/metallb_rbac/metallb-openshift.yaml
+++ b/config/metallb_rbac/metallb-openshift.yaml
@@ -210,6 +210,7 @@ rules:
       - ""
     resources:
       - services
+      - namespaces
     verbs:
       - get
       - list
@@ -274,6 +275,7 @@ rules:
       - services
       - endpoints
       - nodes
+      - namespaces
     verbs:
       - get
       - list

--- a/controllers/metallb_controller_test.go
+++ b/controllers/metallb_controller_test.go
@@ -57,6 +57,7 @@ var _ = Describe("MetalLB Controller", func() {
 				"cp-frr-files": frrImage,
 				"cp-reloader":  speakerImage,
 				"cp-metrics":   speakerImage,
+				"cp-liveness":  speakerImage,
 			}
 
 			By("Creating a MetalLB resource")

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -17,7 +17,7 @@ export PATH=$PATH:$GOPATH/bin
 
 mkdir -p _cache
 
-export METALLB_COMMIT_ID="4b236c70e03c6bc1ae7227e404f561fb159601ee"
+export METALLB_COMMIT_ID="87842bdc6e0e42754f93ecccef2bcdac596ccd06"
 export METALLB_PATH=_cache/metallb
 
 export METALLB_SC_FILE=$(dirname "$0")/securityContext.yaml

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -17,7 +17,7 @@ export PATH=$PATH:$GOPATH/bin
 
 mkdir -p _cache
 
-export METALLB_COMMIT_ID="a917ee063c03ab4f465d142f5fb242d390c842b1"
+export METALLB_COMMIT_ID="4b236c70e03c6bc1ae7227e404f561fb159601ee"
 export METALLB_PATH=_cache/metallb
 
 export METALLB_SC_FILE=$(dirname "$0")/securityContext.yaml

--- a/pkg/helm/testdata/ocp-metrics-speaker.golden
+++ b/pkg/helm/testdata/ocp-metrics-speaker.golden
@@ -158,6 +158,15 @@
                             }
                         ],
                         "image": "frrouting/frr:v7.5.1",
+                        "livenessProbe": {
+                            "exec": {
+                                "command": [
+                                    "/etc/frr_liveness/liveness.sh"
+                                ]
+                            },
+                            "failureThreshold": 3,
+                            "periodSeconds": 5
+                        },
                         "name": "frr",
                         "securityContext": {
                             "capabilities": {
@@ -169,6 +178,15 @@
                                 ]
                             }
                         },
+                        "startupProbe": {
+                            "exec": {
+                                "command": [
+                                    "/etc/frr_liveness/liveness.sh"
+                                ]
+                            },
+                            "failureThreshold": 30,
+                            "periodSeconds": 5
+                        },
                         "volumeMounts": [
                             {
                                 "mountPath": "/var/run/frr",
@@ -177,6 +195,10 @@
                             {
                                 "mountPath": "/etc/frr",
                                 "name": "frr-conf"
+                            },
+                            {
+                                "mountPath": "/etc/frr_liveness",
+                                "name": "frr-liveness"
                             }
                         ]
                     },
@@ -362,6 +384,21 @@
                         "command": [
                             "/bin/sh",
                             "-c",
+                            "cp -f /liveness.sh /etc/frr_liveness/"
+                        ],
+                        "image": "quay.io/metallb/speaker:v0.0.0",
+                        "name": "cp-liveness",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/etc/frr_liveness",
+                                "name": "frr-liveness"
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "/bin/sh",
+                            "-c",
                             "cp -f /frr-metrics /etc/frr_metrics/"
                         ],
                         "image": "quay.io/metallb/speaker:v0.0.0",
@@ -414,6 +451,10 @@
                     {
                         "emptyDir": {},
                         "name": "metrics"
+                    },
+                    {
+                        "emptyDir": {},
+                        "name": "frr-liveness"
                     },
                     {
                         "name": "metrics-certs",

--- a/pkg/helm/testdata/ocp-metrics-speaker.golden
+++ b/pkg/helm/testdata/ocp-metrics-speaker.golden
@@ -159,13 +159,12 @@
                         ],
                         "image": "frrouting/frr:v7.5.1",
                         "livenessProbe": {
-                            "exec": {
-                                "command": [
-                                    "/etc/frr_liveness/liveness.sh"
-                                ]
-                            },
                             "failureThreshold": 3,
-                            "periodSeconds": 5
+                            "httpGet": {
+                                "path": "/livez",
+                                "port": 7473
+                            },
+                            "periodSeconds": 10
                         },
                         "name": "frr",
                         "securityContext": {
@@ -179,12 +178,11 @@
                             }
                         },
                         "startupProbe": {
-                            "exec": {
-                                "command": [
-                                    "/etc/frr_liveness/liveness.sh"
-                                ]
-                            },
                             "failureThreshold": 30,
+                            "httpGet": {
+                                "path": "/livez",
+                                "port": 7473
+                            },
                             "periodSeconds": 5
                         },
                         "volumeMounts": [
@@ -195,10 +193,6 @@
                             {
                                 "mountPath": "/etc/frr",
                                 "name": "frr-conf"
-                            },
-                            {
-                                "mountPath": "/etc/frr_liveness",
-                                "name": "frr-liveness"
                             }
                         ]
                     },
@@ -384,21 +378,6 @@
                         "command": [
                             "/bin/sh",
                             "-c",
-                            "cp -f /liveness.sh /etc/frr_liveness/"
-                        ],
-                        "image": "quay.io/metallb/speaker:v0.0.0",
-                        "name": "cp-liveness",
-                        "volumeMounts": [
-                            {
-                                "mountPath": "/etc/frr_liveness",
-                                "name": "frr-liveness"
-                            }
-                        ]
-                    },
-                    {
-                        "command": [
-                            "/bin/sh",
-                            "-c",
                             "cp -f /frr-metrics /etc/frr_metrics/"
                         ],
                         "image": "quay.io/metallb/speaker:v0.0.0",
@@ -451,10 +430,6 @@
                     {
                         "emptyDir": {},
                         "name": "metrics"
-                    },
-                    {
-                        "emptyDir": {},
-                        "name": "frr-liveness"
                     },
                     {
                         "name": "metrics-certs",

--- a/pkg/helm/testdata/vanilla-metrics-speaker.golden
+++ b/pkg/helm/testdata/vanilla-metrics-speaker.golden
@@ -159,13 +159,12 @@
                         ],
                         "image": "frrouting/frr:v7.5.1",
                         "livenessProbe": {
-                            "exec": {
-                                "command": [
-                                    "/etc/frr_liveness/liveness.sh"
-                                ]
-                            },
                             "failureThreshold": 3,
-                            "periodSeconds": 5
+                            "httpGet": {
+                                "path": "/livez",
+                                "port": 7473
+                            },
+                            "periodSeconds": 10
                         },
                         "name": "frr",
                         "securityContext": {
@@ -179,12 +178,11 @@
                             }
                         },
                         "startupProbe": {
-                            "exec": {
-                                "command": [
-                                    "/etc/frr_liveness/liveness.sh"
-                                ]
-                            },
                             "failureThreshold": 30,
+                            "httpGet": {
+                                "path": "/livez",
+                                "port": 7473
+                            },
                             "periodSeconds": 5
                         },
                         "volumeMounts": [
@@ -195,10 +193,6 @@
                             {
                                 "mountPath": "/etc/frr",
                                 "name": "frr-conf"
-                            },
-                            {
-                                "mountPath": "/etc/frr_liveness",
-                                "name": "frr-liveness"
                             }
                         ]
                     },
@@ -366,21 +360,6 @@
                         "command": [
                             "/bin/sh",
                             "-c",
-                            "cp -f /liveness.sh /etc/frr_liveness/"
-                        ],
-                        "image": "quay.io/metallb/speaker:v0.0.0",
-                        "name": "cp-liveness",
-                        "volumeMounts": [
-                            {
-                                "mountPath": "/etc/frr_liveness",
-                                "name": "frr-liveness"
-                            }
-                        ]
-                    },
-                    {
-                        "command": [
-                            "/bin/sh",
-                            "-c",
                             "cp -f /frr-metrics /etc/frr_metrics/"
                         ],
                         "image": "quay.io/metallb/speaker:v0.0.0",
@@ -433,10 +412,6 @@
                     {
                         "emptyDir": {},
                         "name": "metrics"
-                    },
-                    {
-                        "emptyDir": {},
-                        "name": "frr-liveness"
                     }
                 ]
             }

--- a/pkg/helm/testdata/vanilla-metrics-speaker.golden
+++ b/pkg/helm/testdata/vanilla-metrics-speaker.golden
@@ -158,6 +158,15 @@
                             }
                         ],
                         "image": "frrouting/frr:v7.5.1",
+                        "livenessProbe": {
+                            "exec": {
+                                "command": [
+                                    "/etc/frr_liveness/liveness.sh"
+                                ]
+                            },
+                            "failureThreshold": 3,
+                            "periodSeconds": 5
+                        },
                         "name": "frr",
                         "securityContext": {
                             "capabilities": {
@@ -169,6 +178,15 @@
                                 ]
                             }
                         },
+                        "startupProbe": {
+                            "exec": {
+                                "command": [
+                                    "/etc/frr_liveness/liveness.sh"
+                                ]
+                            },
+                            "failureThreshold": 30,
+                            "periodSeconds": 5
+                        },
                         "volumeMounts": [
                             {
                                 "mountPath": "/var/run/frr",
@@ -177,6 +195,10 @@
                             {
                                 "mountPath": "/etc/frr",
                                 "name": "frr-conf"
+                            },
+                            {
+                                "mountPath": "/etc/frr_liveness",
+                                "name": "frr-liveness"
                             }
                         ]
                     },
@@ -344,6 +366,21 @@
                         "command": [
                             "/bin/sh",
                             "-c",
+                            "cp -f /liveness.sh /etc/frr_liveness/"
+                        ],
+                        "image": "quay.io/metallb/speaker:v0.0.0",
+                        "name": "cp-liveness",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/etc/frr_liveness",
+                                "name": "frr-liveness"
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "/bin/sh",
+                            "-c",
                             "cp -f /frr-metrics /etc/frr_metrics/"
                         ],
                         "image": "quay.io/metallb/speaker:v0.0.0",
@@ -396,6 +433,10 @@
                     {
                         "emptyDir": {},
                         "name": "metrics"
+                    },
+                    {
+                        "emptyDir": {},
+                        "name": "frr-liveness"
                     }
                 ]
             }


### PR DESCRIPTION
cherry-pick of the relevant commits to bring the liveness probe to 4.12,
the second was not clean, had to manually accept commit refs on `.github/workflows/metallb_e2e.yml` and `hack/common.sh`

depends on https://github.com/openshift/metallb/pull/140 - operator-e2e fails locally using quay.io/openshift/origin-metallb:4.12, passes using a custom build of https://github.com/openshift/metallb/pull/140 (the livez endpoint is missing from 4.12)