### PR TITLE
Openshift only: add a e2e test runner file

### DIFF
--- a/hack/ocp_run_e2e.sh
+++ b/hack/ocp_run_e2e.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export PATH=$PATH:$(pwd)/_cache
+export OO_INSTALL_NAMESPACE=openshift-metallb-operator
+export USE_LOCAL_RESOURCES=true
+export IS_OPENSHIFT=1
+
+hack/validate_ocp_bundle.sh
+go test --tags=validationtests -v ./test/e2e/validation -ginkgo.v -junit /logs/artifacts/ -report /logs/artifacts/
+go test --tags=e2etests -v ./test/e2e/functional -ginkgo.v -gingko.skip "frr-k8s" -junit /logs/artifacts/ -report /logs/artifacts/


### PR DESCRIPTION
We want to control which tests we run from the metallb operator repo, so it's easier to change a skip contextually to a pr for example.