### PR TITLE
OCP only: fix the runner script

### DIFF
--- a/hack/ocp_run_e2e.sh
+++ b/hack/ocp_run_e2e.sh
@@ -7,4 +7,4 @@ export IS_OPENSHIFT=1
 
 hack/validate_ocp_bundle.sh
 go test --tags=validationtests -v ./test/e2e/validation -ginkgo.v -junit /logs/artifacts/ -report /logs/artifacts/
-go test --tags=e2etests -v ./test/e2e/functional -ginkgo.v -gingko.skip "frr-k8s" -junit /logs/artifacts/ -report /logs/artifacts/
+go test --tags=e2etests -v ./test/e2e/functional -ginkgo.v -ginkgo.skip "frr-k8s" -junit /logs/artifacts/ -report /logs/artifacts/


### PR DESCRIPTION
Fixing the e2e script because of a typo.