### PR TITLE
OCPBUGS-28364: Add a .snyk configuration file

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,8 @@
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    - vendor/**
+    - "**/*_test.go"
+    - "test/**"


### PR DESCRIPTION
Skipping vendor, e2e tests and tests.