### PR TITLE
OCPBUGS-35754: D/S CSV: override the frr-k8s image

### DIFF
--- a/manifests/stable/metallb-operator.clusterserviceversion.yaml
+++ b/manifests/stable/metallb-operator.clusterserviceversion.yaml
@@ -867,6 +867,8 @@ spec:
                   value: "true"
                 - name: FRR_IMAGE
                   value: quay.io/openshift/origin-metallb-frr:4.16
+                - name: FRRK8S_IMAGE
+                  value: quay.io/openshift/origin-metallb-frr:4.16
                 - name: KUBE_RBAC_PROXY_IMAGE
                   value: quay.io/openshift/origin-kube-rbac-proxy:4.16
                 - name: DEPLOY_KUBE_RBAC_PROXIES


### PR DESCRIPTION
The operator is currently pulling the upstream FRR-K8s image while it should consume the d/s one.
