### PR TITLE
AUTH-482: set required-scc for openshift workloads

### DIFF
--- a/manifests/stable/metallb-operator.clusterserviceversion.yaml
+++ b/manifests/stable/metallb-operator.clusterserviceversion.yaml
@@ -870,6 +870,8 @@ spec:
             strategy: {}
             template:
               metadata:
+                annotations:
+                    openshift.io/required-scc: restricted-v2 
                 labels:
                   control-plane: controller-manager
               spec:
@@ -960,6 +962,8 @@ spec:
                 annotations:
                   prometheus.io/port: "7472"
                   prometheus.io/scrape: "true"
+                  openshift.io/required-scc: restricted-v2 
+
                 labels:
                   app: metallb
                   component: webhook-server


### PR DESCRIPTION
This PR pins the required SCC to the openshift-metallb-system workload.
Workloads:
1- metallb-operator-webhook-server
2- metallb-operator-controller-manager
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb-operator/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
