### PR TITLE
Openshift: Add env variables to deploy frr-k8s from CNO

### DIFF
--- a/manifests/stable/metallb-operator.clusterserviceversion.yaml
+++ b/manifests/stable/metallb-operator.clusterserviceversion.yaml
@@ -913,6 +913,10 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.namespace
+                      - name: FRRK8S_EXTERNAL_NAMESPACE
+                        value: "openshift-frr-k8s"
+                      - name: DEPLOY_FRRK8S_FROM_CNO
+                        value: "true"
                       - name: DEPLOY_PODMONITORS
                         value: "false"
                       - name: DEPLOY_SERVICEMONITORS


### PR DESCRIPTION
We add the env variables that instruct the operator to deploy
frr-k8s from CNO rather than directly from helm.