### PR TITLE
NO-JIRA: Fix 4.19 CSV references

### DIFF
--- a/manifests/stable/metallb-operator.clusterserviceversion.yaml
+++ b/manifests/stable/metallb-operator.clusterserviceversion.yaml
@@ -452,7 +452,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: metallb-operator.v4.18.0
+  name: metallb-operator.v4.19.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1302,7 +1302,7 @@ spec:
   minKubeVersion: 1.26.0
   provider:
     name: Red Hat
-  version: 4.18.0
+  version: 4.19.0
   webhookdefinitions:
     - admissionReviewVersions:
         - v1


### PR DESCRIPTION
Fix CSV validation by ART, currently failing with:
```
Bundle ose-metallb-operator-bundle-container-v4.19.0.202502102307.p0.g6a06990.assembly.stream.el9-2
 CSV metadata.name has no datestamp: metallb-operator.v4.18.0
Bundle ose-metallb-operator-bundle-container-v4.19.0.202502102307.p0.g6a06990.assembly.stream.el9-2
 CSV spec.version has no datestamp: 4.18.0
```