### PR TITLE
OCPBUGS-55021: [4.17] OpenShift only: sync stable manifests with dynamicASN

### DIFF
--- a/manifests/stable/metallb.io_bgppeers.yaml
+++ b/manifests/stable/metallb.io_bgppeers.yaml
@@ -194,6 +194,17 @@ spec:
                 description: To set if we want to disable MP BGP that will separate
                   IPv4 and IPv6 route exchanges into distinct BGP sessions.
                 type: boolean
+              dynamicASN:
+                description: |-
+                  DynamicASN detects the AS number to use for the remote end of the session
+                  without explicitly setting it via the ASN field. Limited to:
+                  internal - if the neighbor's ASN is different than MyASN connection is denied.
+                  external - if the neighbor's ASN is the same as MyASN the connection is denied.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                enum:
+                - internal
+                - external
+                type: string
               ebgpMultiHop:
                 description: To set if the BGPPeer is multi-hops away. Needed for
                   FRR mode only.
@@ -296,7 +307,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               peerASN:
-                description: AS number to expect from the remote end of the session.
+                description: |-
+                  AS number to expect from the remote end of the session.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
                 format: int32
                 maximum: 4294967295
                 minimum: 0
@@ -323,7 +336,6 @@ spec:
                 type: string
             required:
             - myASN
-            - peerASN
             - peerAddress
             type: object
           status:


### PR DESCRIPTION
The CRD changes were brought to 4.17 without updating the stable manifests.
 should have been part of https://github.com/openshift/metallb-operator/pull/265