### PR TITLE
OCPBUGS-60378: [release-4.19] Align manifests to 4.19 to fix the failing operator-e2e job

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -16,7 +16,7 @@ LABEL com.redhat.delivery.operator.bundle=true
 
 # This second label tells the pipeline which versions of OpenShift the operator supports.
 # This is used to control which index images should include this operator.
-LABEL com.redhat.openshift.versions="v4.18"
+LABEL com.redhat.openshift.versions="v4.19"
 
 # This third label tells the pipeline that this operator should *also* be supported on OCP 4.4 and
 # earlier.  It is used to control whether or not the pipeline should attempt to automatically

--- a/manifests/metallb-operator.package.yaml
+++ b/manifests/metallb-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: metallb-operator
 channels:
 - name: "stable"
-  currentCSV: metallb-operator.v4.18.0
+  currentCSV: metallb-operator.v4.19.0

--- a/manifests/ocpcsv/align.sh
+++ b/manifests/ocpcsv/align.sh
@@ -4,7 +4,7 @@ export OPERATOR_SDK=_cache/operator-sdk
 make operator-sdk
 export KUSTOMIZE=_cache/kustomize
 make kustomize
-VERSION="4.18"
+VERSION="4.19"
 CSV_VERSION="$VERSION.0"
 
 

--- a/manifests/ocpcsv/bases/metallb-operator.clusterserviceversion.yaml
+++ b/manifests/ocpcsv/bases/metallb-operator.clusterserviceversion.yaml
@@ -5,9 +5,9 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/openshift/origin-metallb-operator:4.18
+    containerImage: quay.io/openshift/origin-metallb-operator:4.19
     createdAt: "2021-06-28 00:00:00"
-    olm.skipRange: ">=4.8.0 <4.18.0"
+    olm.skipRange: ">=4.8.0 <4.19.0"
     description: An operator for deploying MetalLB on a kubernetes cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.8.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
@@ -19,7 +19,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.ppc64le: supported
-  name: metallb-operator.v4.18.0
+  name: metallb-operator.v4.19.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -59,7 +59,7 @@ spec:
   maturity: alpha
   provider:
     name: Community
-  version: 4.18.0
+  version: 4.19.0
   labels:
     olm-owner-enterprise-app: metallb-operator
-    olm-status-descriptors: metallb-operator.v4.18.0
+    olm-status-descriptors: metallb-operator.v4.19.0

--- a/manifests/ocpcsv/controller-webhook-patch.yaml
+++ b/manifests/ocpcsv/controller-webhook-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: webhook-server
-        image: quay.io/openshift/origin-metallb:4.18
+        image: quay.io/openshift/origin-metallb:4.19
         securityContext:
           $patch: delete
         env:

--- a/manifests/ocpcsv/ocpvariables.yaml
+++ b/manifests/ocpcsv/ocpvariables.yaml
@@ -10,17 +10,17 @@ spec:
         - name: manager
           env:
           - name: SPEAKER_IMAGE
-            value: quay.io/openshift/origin-metallb:4.18
+            value: quay.io/openshift/origin-metallb:4.19
           - name: CONTROLLER_IMAGE
-            value: quay.io/openshift/origin-metallb:4.18
+            value: quay.io/openshift/origin-metallb:4.19
           - name: ENABLE_OPERATOR_WEBHOOK
             value: "true"
           - name: METALLB_BGP_TYPE
             value: frr
           - name: FRR_IMAGE
-            value: quay.io/openshift/origin-metallb-frr:4.18
+            value: quay.io/openshift/origin-metallb-frr:4.19
           - name: KUBE_RBAC_PROXY_IMAGE
-            value: quay.io/openshift/origin-kube-rbac-proxy:4.18
+            value: quay.io/openshift/origin-kube-rbac-proxy:4.19
           - name: DEPLOY_KUBE_RBAC_PROXIES
             value: "true"
           - name: DEPLOY_PODMONITORS
@@ -43,4 +43,4 @@ spec:
             value: "9121"
           - name: MEMBER_LIST_BIND_PORT
             value: "9122"
-          image: quay.io/openshift/origin-metallb-operator:4.18
+          image: quay.io/openshift/origin-metallb-operator:4.19

--- a/manifests/stable/image-references
+++ b/manifests/stable/image-references
@@ -6,16 +6,16 @@ spec:
   - name: metallb-rhel9-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-metallb-operator:4.18
+      name: quay.io/openshift/origin-metallb-operator:4.19
   - name: metallb-rhel9
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-metallb:4.18
+      name: quay.io/openshift/origin-metallb:4.19
   - name: metallb-frr-rhel9
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-metallb-frr:4.18
+      name: quay.io/openshift/origin-metallb-frr:4.19
   - name: kube-rbac-proxy
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-kube-rbac-proxy:4.18
+      name: quay.io/openshift/origin-kube-rbac-proxy:4.19

--- a/manifests/stable/metallb-operator.clusterserviceversion.yaml
+++ b/manifests/stable/metallb-operator.clusterserviceversion.yaml
@@ -432,10 +432,10 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/openshift/origin-metallb-operator:4.18
+    containerImage: quay.io/openshift/origin-metallb-operator:4.19
     createdAt: "2023-06-06T15:25:00Z"
     description: An operator for deploying MetalLB on a kubernetes cluster.
-    olm.skipRange: '>=4.8.0 <4.18.0'
+    olm.skipRange: '>=4.8.0 <4.19.0'
     operatorframework.io/suggested-namespace: metallb-system
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -910,17 +910,17 @@ spec:
                       - /manager
                     env:
                       - name: SPEAKER_IMAGE
-                        value: quay.io/openshift/origin-metallb:4.18
+                        value: quay.io/openshift/origin-metallb:4.19
                       - name: CONTROLLER_IMAGE
-                        value: quay.io/openshift/origin-metallb:4.18
+                        value: quay.io/openshift/origin-metallb:4.19
                       - name: FRR_IMAGE
-                        value: quay.io/openshift/origin-metallb-frr:4.18
+                        value: quay.io/openshift/origin-metallb-frr:4.19
                       - name: KUBE_RBAC_PROXY_IMAGE
-                        value: quay.io/openshift/origin-kube-rbac-proxy:4.18
+                        value: quay.io/openshift/origin-kube-rbac-proxy:4.19
                       - name: DEPLOY_KUBE_RBAC_PROXIES
                         value: "true"
                       - name: FRRK8S_IMAGE
-                        value: quay.io/openshift/origin-metallb-frr:4.18
+                        value: quay.io/openshift/origin-metallb-frr:4.19
                       - name: OPERATOR_NAMESPACE
                         valueFrom:
                           fieldRef:
@@ -949,7 +949,7 @@ spec:
                         value: "true"
                       - name: CNO_MIN_FRRK8S_VERSION
                         value: "4.17.0-0"
-                    image: quay.io/openshift/origin-metallb-operator:4.18
+                    image: quay.io/openshift/origin-metallb-operator:4.19
                     name: manager
                     ports:
                       - containerPort: 9443
@@ -1012,7 +1012,7 @@ spec:
                     env:
                       - name: METALLB_BGP_TYPE
                         value: frr
-                    image: quay.io/openshift/origin-metallb:4.18
+                    image: quay.io/openshift/origin-metallb:4.19
                     livenessProbe:
                       failureThreshold: 3
                       httpGet:
@@ -1313,7 +1313,7 @@ spec:
     - metallb-operator
   labels:
     olm-owner-enterprise-app: metallb-operator
-    olm-status-descriptors: metallb-operator.v4.18.0
+    olm-status-descriptors: metallb-operator.v4.19.0
   links:
     - name: MetalLB Operator
       url: https://github.com/openshift/metallb-operator


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb-operator/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind bug
/kind cleanup

**What this PR does / why we need it**:
This PR updates manifest references to `4.19`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NA
```
