### PR TITLE
WIP TEST CI: remove ginkgo.skip for bgp type tests

### DIFF
--- a/hack/ocp_run_e2e.sh
+++ b/hack/ocp_run_e2e.sh
@@ -5,6 +5,9 @@ export OO_INSTALL_NAMESPACE=openshift-metallb-operator
 export USE_LOCAL_RESOURCES=true
 export IS_OPENSHIFT=1
 export FRRK8S_EXTERNAL_NAMESPACE="openshift-frr-k8s"
+export FRRK8S_DAEMONSET_LABEL_SELECTOR="component=frr-k8s"
+export FRRK8S_STATUSCLEANER_DEPLOYMENT_NAME="frr-k8s-statuscleaner"
+export FRRK8S_STATUSCLEANER_LABEL_SELECTOR="component=frr-k8s-statuscleaner"
 
 hack/validate_ocp_bundle.sh
 go test --tags=validationtests -v ./test/e2e/validation -ginkgo.v -junit /logs/artifacts/ -report /logs/artifacts/

--- a/hack/ocp_run_e2e.sh
+++ b/hack/ocp_run_e2e.sh
@@ -8,4 +8,4 @@ export FRRK8S_EXTERNAL_NAMESPACE="openshift-frr-k8s"
 
 hack/validate_ocp_bundle.sh
 go test --tags=validationtests -v ./test/e2e/validation -ginkgo.v -junit /logs/artifacts/ -report /logs/artifacts/
-go test --tags=e2etests -v ./test/e2e/functional -ginkgo.v -ginkgo.skip "with BGP type" -junit /logs/artifacts/ -report /logs/artifacts/
+go test --tags=e2etests -v ./test/e2e/functional -ginkgo.v -junit /logs/artifacts/ -report /logs/artifacts/


### PR DESCRIPTION
removed ginkgo.skip from ocp_run_e2e.sh
the unwanted tests are already skipped in test file itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage to run all functional specs, now including comprehensive BGP-type scenarios.

* **Chores**
  * Added configurable environment variables to the e2e runner to select the daemonset and status-cleaner components used during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->