### PR TITLE
Bug 86703: fix OCP ServiceMonitor rejection due to filesystem access

### DIFF
--- a/pkg/helm/config.go
+++ b/pkg/helm/config.go
@@ -64,6 +64,14 @@ func setOcpMonitorFields(obj *unstructured.Unstructured) error {
 		if err != nil {
 			return err
 		}
+		// OCP's user-workload Prometheus sets arbitraryFSAccessThroughSMs
+		// to deny, blocking bearerTokenFile and tlsConfig file paths.
+		// Remove all file-based fields; the Helm values already supply
+		// secret/configmap-based references for OCP.
+		unstructured.RemoveNestedField(ep.(map[string]interface{}), "bearerTokenFile")
+		unstructured.RemoveNestedField(ep.(map[string]interface{}), "tlsConfig", "caFile")
+		unstructured.RemoveNestedField(ep.(map[string]interface{}), "tlsConfig", "certFile")
+		unstructured.RemoveNestedField(ep.(map[string]interface{}), "tlsConfig", "keyFile")
 	}
 	err = unstructured.SetNestedSlice(obj.Object, eps, "spec", "endpoints")
 	if err != nil {
@@ -108,11 +116,28 @@ func ocpPromConfigFor(component, namespace string) (map[string]interface{}, map[
 		"service.beta.openshift.io/serving-cert-secret-name": secretName,
 	}
 
+	// Use secret/configmap references instead of file paths.
+	// OCP's user-workload Prometheus sets arbitraryFSAccessThroughSMs to
+	// deny, blocking any ServiceMonitor that references the filesystem
+	// via bearerTokenFile or tlsConfig file fields.
 	tlsConfig := map[string]interface{}{
-		"caFile":             "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
+		"ca": map[string]interface{}{
+			"configMap": map[string]interface{}{
+				"name": "openshift-service-ca.crt",
+				"key":  "service-ca.crt",
+			},
+		},
+		"cert": map[string]interface{}{
+			"secret": map[string]interface{}{
+				"name": secretName,
+				"key":  "tls.crt",
+			},
+		},
+		"keySecret": map[string]interface{}{
+			"name": secretName,
+			"key":  "tls.key",
+		},
 		"serverName":         fmt.Sprintf("%s-monitor-service.%s.svc", component, namespace),
-		"certFile":           "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
-		"keyFile":            "/etc/prometheus/secrets/metrics-client-certs/tls.key",
 		"insecureSkipVerify": false,
 	}
 

--- a/pkg/helm/testdata/ocp-metrics-controller-monitor.golden
+++ b/pkg/helm/testdata/ocp-metrics-controller-monitor.golden
@@ -17,15 +17,27 @@
     "spec": {
         "endpoints": [
             {
-                "bearerTokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",
                 "honorLabels": true,
                 "port": "metricshttps",
                 "scheme": "https",
                 "tlsConfig": {
-                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
-                    "certFile": "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
+                    "ca": {
+                        "configMap": {
+                            "key": "service-ca.crt",
+                            "name": "openshift-service-ca.crt"
+                        }
+                    },
+                    "cert": {
+                        "secret": {
+                            "key": "tls.crt",
+                            "name": "controller-certs-secret"
+                        }
+                    },
                     "insecureSkipVerify": false,
-                    "keyFile": "/etc/prometheus/secrets/metrics-client-certs/tls.key",
+                    "keySecret": {
+                        "key": "tls.key",
+                        "name": "controller-certs-secret"
+                    },
                     "serverName": "controller-monitor-service.metallb-test-namespace.svc"
                 }
             }

--- a/pkg/helm/testdata/ocp-metrics-frr-k8s-monitor.golden
+++ b/pkg/helm/testdata/ocp-metrics-frr-k8s-monitor.golden
@@ -18,7 +18,6 @@
     "spec": {
         "endpoints": [
             {
-                "bearerTokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",
                 "honorLabels": true,
                 "metricRelabelings": [
                     {
@@ -41,15 +40,27 @@
                 "port": "metricshttps",
                 "scheme": "https",
                 "tlsConfig": {
-                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
-                    "certFile": "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
+                    "ca": {
+                        "configMap": {
+                            "key": "service-ca.crt",
+                            "name": "openshift-service-ca.crt"
+                        }
+                    },
+                    "cert": {
+                        "secret": {
+                            "key": "tls.crt",
+                            "name": "frr-k8s-certs-secret"
+                        }
+                    },
                     "insecureSkipVerify": false,
-                    "keyFile": "/etc/prometheus/secrets/metrics-client-certs/tls.key",
+                    "keySecret": {
+                        "key": "tls.key",
+                        "name": "frr-k8s-certs-secret"
+                    },
                     "serverName": "frr-k8s-monitor-service.metallb-test-namespace.svc"
                 }
             },
             {
-                "bearerTokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",
                 "honorLabels": true,
                 "metricRelabelings": [
                     {
@@ -72,10 +83,23 @@
                 "port": "frrmetricshttps",
                 "scheme": "https",
                 "tlsConfig": {
-                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
-                    "certFile": "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
+                    "ca": {
+                        "configMap": {
+                            "key": "service-ca.crt",
+                            "name": "openshift-service-ca.crt"
+                        }
+                    },
+                    "cert": {
+                        "secret": {
+                            "key": "tls.crt",
+                            "name": "frr-k8s-certs-secret"
+                        }
+                    },
                     "insecureSkipVerify": false,
-                    "keyFile": "/etc/prometheus/secrets/metrics-client-certs/tls.key",
+                    "keySecret": {
+                        "key": "tls.key",
+                        "name": "frr-k8s-certs-secret"
+                    },
                     "serverName": "frr-k8s-monitor-service.metallb-test-namespace.svc"
                 }
             }

--- a/pkg/helm/testdata/ocp-metrics-speaker-monitor.golden
+++ b/pkg/helm/testdata/ocp-metrics-speaker-monitor.golden
@@ -18,28 +18,52 @@
     "spec": {
         "endpoints": [
             {
-                "bearerTokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",
                 "honorLabels": true,
                 "port": "metricshttps",
                 "scheme": "https",
                 "tlsConfig": {
-                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
-                    "certFile": "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
+                    "ca": {
+                        "configMap": {
+                            "key": "service-ca.crt",
+                            "name": "openshift-service-ca.crt"
+                        }
+                    },
+                    "cert": {
+                        "secret": {
+                            "key": "tls.crt",
+                            "name": "speaker-certs-secret"
+                        }
+                    },
                     "insecureSkipVerify": false,
-                    "keyFile": "/etc/prometheus/secrets/metrics-client-certs/tls.key",
+                    "keySecret": {
+                        "key": "tls.key",
+                        "name": "speaker-certs-secret"
+                    },
                     "serverName": "speaker-monitor-service.metallb-test-namespace.svc"
                 }
             },
             {
-                "bearerTokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",
                 "honorLabels": true,
                 "port": "frrmetricshttps",
                 "scheme": "https",
                 "tlsConfig": {
-                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
-                    "certFile": "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
+                    "ca": {
+                        "configMap": {
+                            "key": "service-ca.crt",
+                            "name": "openshift-service-ca.crt"
+                        }
+                    },
+                    "cert": {
+                        "secret": {
+                            "key": "tls.crt",
+                            "name": "speaker-certs-secret"
+                        }
+                    },
                     "insecureSkipVerify": false,
-                    "keyFile": "/etc/prometheus/secrets/metrics-client-certs/tls.key",
+                    "keySecret": {
+                        "key": "tls.key",
+                        "name": "speaker-certs-secret"
+                    },
                     "serverName": "speaker-monitor-service.metallb-test-namespace.svc"
                 }
             }


### PR DESCRIPTION
## Summary

OpenShift's user-workload Prometheus sets `arbitraryFSAccessThroughSMs` to deny, which causes the Prometheus Operator to reject all MetalLB ServiceMonitors (`speaker-monitor`, `controller-monitor`, `frr-k8s-monitor`) that reference local file paths via `bearerTokenFile` or `tlsConfig` file fields (`caFile`, `certFile`, `keyFile`). This triggers the `PrometheusOperatorRejectedResources` alert on every OCP cluster (4.18–4.22) with MetalLB and user-workload monitoring enabled.

Since the MetalLB Operator continuously reconciles these ServiceMonitors, customers cannot fix them manually.

## Changes

- **`pkg/helm/config.go` – `ocpPromConfigFor()`**: Replace file-based `tlsConfig` paths with secret/configmap references that point to existing resources in `metallb-system`:
  - `ca.configMap` → `openshift-service-ca.crt` (injected by OpenShift service-ca controller)
  - `cert.secret` → `{component}-certs-secret` (created by serving cert signer)
  - `keySecret` → `{component}-certs-secret`

- **`pkg/helm/config.go` – `setOcpMonitorFields()`**: Strip `bearerTokenFile` and all residual file-based `tlsConfig` fields (`caFile`, `certFile`, `keyFile`) from every ServiceMonitor endpoint during OCP post-processing. mTLS via client cert/key in `tlsConfig` is sufficient for authentication.

- **Golden test files**: Updated all three OCP ServiceMonitor test fixtures to reflect the new structure.

## Before (rejected by Prometheus Operator)

```yaml
spec:
  endpoints:
  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
    tlsConfig:
      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
```

## After (accepted by Prometheus Operator)

```yaml
spec:
  endpoints:
  - tlsConfig:
      ca:
        configMap:
          name: openshift-service-ca.crt
          key: service-ca.crt
      cert:
        secret:
          name: speaker-certs-secret
          key: tls.crt
      keySecret:
        name: speaker-certs-secret
        key: tls.key
```

## Verification

- Tested on OCP 4.20.22 – `PrometheusOperatorRejectedResources` alert **resolved**
- Bug confirmed present on OCP 4.20.22, 4.21.9, and 4.22.0-rc.4
- All 9 unit tests in `pkg/helm` pass

## Jira

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-86703


Made with [Cursor](https://cursor.com)