### PR TITLE
WIP: onlywebhook: support tls params

### DIFF
--- a/bin/metallb-operator.yaml
+++ b/bin/metallb-operator.yaml
@@ -4616,6 +4616,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - delete
+  - list
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create
@@ -4937,6 +4944,9 @@ spec:
         - --webhook-mode=onlywebhook
         - --port=9120
         - --log-level=info
+        - --tls-cipher-suites=$(TLS_CIPHER_SUITES)
+        - --tls-min-version=$(TLS_MIN_VERSION)
+        - --tls-curve-preferences=$(TLS_CURVE_PREFERENCES)
         env:
         - name: METALLB_POD_NAME
           valueFrom:
@@ -4944,6 +4954,24 @@ spec:
               fieldPath: metadata.name
         - name: METALLB_BGP_TYPE
           value: native
+        - name: TLS_CIPHER_SUITES
+          valueFrom:
+            configMapKeyRef:
+              key: TLS_CIPHER_SUITES
+              name: metallb-tls-config
+              optional: false
+        - name: TLS_MIN_VERSION
+          valueFrom:
+            configMapKeyRef:
+              key: TLS_MIN_VERSION
+              name: metallb-tls-config
+              optional: false
+        - name: TLS_CURVE_PREFERENCES
+          valueFrom:
+            configMapKeyRef:
+              key: TLS_CURVE_PREFERENCES
+              name: metallb-tls-config
+              optional: false
         image: quay.io/metallb/controller:main
         livenessProbe:
           failureThreshold: 3

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -433,7 +433,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/metallb/metallb-operator
-    createdAt: "2026-05-10T10:48:05Z"
+    createdAt: "2026-06-03T08:10:25Z"
     description: An operator for deploying MetalLB on a kubernetes cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -906,6 +906,7 @@ spec:
                   - args:
                       - --enable-leader-election
                       - --disable-cert-rotation=true
+                      - --external-metallb-webhook-server
                     command:
                       - /manager
                     env:
@@ -981,6 +982,9 @@ spec:
                       - --port=9120
                       - --log-level=info
                       - --webhook-mode=onlywebhook
+                      - --tls-cipher-suites=$(TLS_CIPHER_SUITES)
+                      - --tls-min-version=$(TLS_MIN_VERSION)
+                      - --tls-curve-preferences=$(TLS_CURVE_PREFERENCES)
                     env:
                       - name: METALLB_POD_NAME
                         valueFrom:
@@ -988,6 +992,24 @@ spec:
                             fieldPath: metadata.name
                       - name: METALLB_BGP_TYPE
                         value: native
+                      - name: TLS_CIPHER_SUITES
+                        valueFrom:
+                          configMapKeyRef:
+                            key: TLS_CIPHER_SUITES
+                            name: metallb-tls-config
+                            optional: false
+                      - name: TLS_MIN_VERSION
+                        valueFrom:
+                          configMapKeyRef:
+                            key: TLS_MIN_VERSION
+                            name: metallb-tls-config
+                            optional: false
+                      - name: TLS_CURVE_PREFERENCES
+                        valueFrom:
+                          configMapKeyRef:
+                            key: TLS_CURVE_PREFERENCES
+                            name: metallb-tls-config
+                            optional: false
                     image: quay.io/metallb/controller:main
                     livenessProbe:
                       failureThreshold: 3
@@ -1262,6 +1284,13 @@ spec:
               verbs:
                 - create
                 - patch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - delete
+                - list
             - apiGroups:
                 - ""
               resources:

--- a/config/manifests/disable-cert-rotation.yaml
+++ b/config/manifests/disable-cert-rotation.yaml
@@ -13,6 +13,9 @@ spec:
         - --port=9120
         - --log-level=info
         - --webhook-mode=onlywebhook
+        - --tls-cipher-suites=$(TLS_CIPHER_SUITES)
+        - --tls-min-version=$(TLS_MIN_VERSION)
+        - --tls-curve-preferences=$(TLS_CURVE_PREFERENCES)
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -27,3 +30,4 @@ spec:
         args:
         - --enable-leader-election
         - --disable-cert-rotation=true
+        - --external-metallb-webhook-server

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -151,6 +151,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - delete
+  - list
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create

--- a/config/webhook/backend/backend.yaml
+++ b/config/webhook/backend/backend.yaml
@@ -23,6 +23,9 @@ spec:
         - --webhook-mode=onlywebhook
         - --port=9120
         - --log-level=info
+        - --tls-cipher-suites=$(TLS_CIPHER_SUITES)
+        - --tls-min-version=$(TLS_MIN_VERSION)
+        - --tls-curve-preferences=$(TLS_CURVE_PREFERENCES)
         image: controller
         name: webhook-server
         ports:
@@ -64,6 +67,24 @@ spec:
                 fieldPath: metadata.name
           - name: METALLB_BGP_TYPE
             value: "native"
+          - name: TLS_CIPHER_SUITES
+            valueFrom:
+              configMapKeyRef:
+                name: metallb-tls-config
+                key: TLS_CIPHER_SUITES
+                optional: false
+          - name: TLS_MIN_VERSION
+            valueFrom:
+              configMapKeyRef:
+                name: metallb-tls-config
+                key: TLS_MIN_VERSION
+                optional: false
+          - name: TLS_CURVE_PREFERENCES
+            valueFrom:
+              configMapKeyRef:
+                name: metallb-tls-config
+                key: TLS_CURVE_PREFERENCES
+                optional: false
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -42,6 +43,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -58,8 +60,9 @@ import (
 )
 
 const (
-	caName         = "cert"
-	caOrganization = "metallb"
+	caName           = "cert"
+	caOrganization   = "metallb"
+	tlsConfigMapName = "metallb-tls-config"
 )
 
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs="*"
@@ -94,11 +97,12 @@ func main() {
 		metricsAddr          = flag.String("metrics-addr", ":0", "The address the metric endpoint binds to.")
 		enableLeaderElection = flag.Bool("enable-leader-election", false, "Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-		disableCertRotation = flag.Bool("disable-cert-rotation", false, "disable automatic generation and rotation of webhook TLS certificates/keys")
-		certDir             = flag.String("cert-dir", "/tmp/k8s-webhook-server/serving-certs", "The directory where certs are stored")
-		certServiceName     = flag.String("cert-service-name", "metallb-operator-webhook-service", "The service name used to generate the TLS cert's hostname")
-		port                = flag.Int("port", 8080, "HTTP listening port to check operator readiness")
-		withWebhookHTTP2    = flag.Bool("webhook-http2", false, "enables http2 for the webhook endpoint")
+		disableCertRotation   = flag.Bool("disable-cert-rotation", false, "disable automatic generation and rotation of webhook TLS certificates/keys")
+		certDir               = flag.String("cert-dir", "/tmp/k8s-webhook-server/serving-certs", "The directory where certs are stored")
+		certServiceName       = flag.String("cert-service-name", "metallb-operator-webhook-service", "The service name used to generate the TLS cert's hostname")
+		port                  = flag.Int("port", 8080, "HTTP listening port to check operator readiness")
+		withWebhookHTTP2      = flag.Bool("webhook-http2", false, "enables http2 for the webhook endpoint")
+		externalWebhookServer = flag.Bool("external-metallb-webhook-server", false, "whether a separate metallb webhook server deployment exists")
 	)
 	flag.Parse()
 
@@ -137,6 +141,23 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "failed to parse TLS configuration")
 		os.Exit(1)
+	}
+
+	cl, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "failed to create client")
+		os.Exit(1)
+	}
+	if err := syncTLSConfigMap(ctx, cl, envParams); err != nil {
+		setupLog.Error(err, "failed to sync TLS ConfigMap")
+		os.Exit(1)
+	}
+	if *externalWebhookServer {
+		// We delete the metallb webhook server pods to pick up the new TLS config from the ConfigMap.
+		if err := deleteWebhookServerPods(ctx, cl, envParams.Namespace); err != nil {
+			setupLog.Error(err, "failed to restart webhook server pods")
+			os.Exit(1)
+		}
 	}
 
 	jsonEnv, err := json.Marshal(envParams)
@@ -248,6 +269,50 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+func syncTLSConfigMap(ctx context.Context, cl client.Client, envConfig params.EnvConfig) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tlsConfigMapName,
+			Namespace: envConfig.Namespace,
+		},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, cl, cm, func() error {
+		cm.Data = map[string]string{
+			"TLS_CIPHER_SUITES":     envConfig.TLSCipherSuites,
+			"TLS_MIN_VERSION":       envConfig.TLSMinVersion,
+			"TLS_CURVE_PREFERENCES": envConfig.TLSCurvePreferences,
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	setupLog.Info("synced TLS ConfigMap", "name", tlsConfigMapName)
+	return nil
+}
+
+// +kubebuilder:rbac:groups="",namespace=metallb-system,resources=pods,verbs=list;delete
+
+func deleteWebhookServerPods(ctx context.Context, cl client.Client, namespace string) error {
+	podList := &corev1.PodList{}
+	if err := cl.List(ctx, podList,
+		client.InNamespace(namespace),
+		client.MatchingLabels{
+			"app":       "metallb",
+			"component": "webhook-server",
+		},
+	); err != nil {
+		return err
+	}
+	for i := range podList.Items {
+		setupLog.Info("deleting webhook server pod", "pod", podList.Items[i].Name)
+		if err := cl.Delete(ctx, &podList.Items[i]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func webhookServer(port int, withHTTP2 bool, tlsOpt func(*tls.Config)) webhook.Server {

--- a/manifests/stable/metallb-operator.clusterserviceversion.yaml
+++ b/manifests/stable/metallb-operator.clusterserviceversion.yaml
@@ -440,7 +440,7 @@ metadata:
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
-    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/tls-profiles: "true"
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
@@ -919,6 +919,7 @@ spec:
                   - args:
                       - --enable-leader-election
                       - --disable-cert-rotation=true
+                      - --external-metallb-webhook-server
                     command:
                       - /manager
                     env:
@@ -1016,6 +1017,9 @@ spec:
                       - --port=9120
                       - --log-level=info
                       - --webhook-mode=onlywebhook
+                      - --tls-cipher-suites=$(TLS_CIPHER_SUITES)
+                      - --tls-min-version=$(TLS_MIN_VERSION)
+                      - --tls-curve-preferences=$(TLS_CURVE_PREFERENCES)
                     command:
                     - /controller
                     env:
@@ -1025,6 +1029,24 @@ spec:
                             fieldPath: metadata.name
                       - name: METALLB_BGP_TYPE
                         value: frr
+                      - name: TLS_CIPHER_SUITES
+                        valueFrom:
+                          configMapKeyRef:
+                            key: TLS_CIPHER_SUITES
+                            name: metallb-tls-config
+                            optional: false
+                      - name: TLS_MIN_VERSION
+                        valueFrom:
+                          configMapKeyRef:
+                            key: TLS_MIN_VERSION
+                            name: metallb-tls-config
+                            optional: false
+                      - name: TLS_CURVE_PREFERENCES
+                        valueFrom:
+                          configMapKeyRef:
+                            key: TLS_CURVE_PREFERENCES
+                            name: metallb-tls-config
+                            optional: false
                     image: quay.io/openshift/origin-metallb:4.22
                     livenessProbe:
                       failureThreshold: 3
@@ -1264,6 +1286,13 @@ spec:
                 - patch
                 - update
                 - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - delete
+                - list
           serviceAccountName: manager-account
         - rules:
             - apiGroups:


### PR DESCRIPTION
When wiring the tls params we forgot about the onlywebhook pod. Since OLM manages it (and provides it webhook configurations) we add a new configmap (managed by the operator on startup) for the params consumed by the onlywebhook pod as env variables, and restart the webhook pod (so that the deployment re-reads the configmap). The env variables are set as `optional: false` to ensure the webhook pod never comes up with the wrong tls params (w.r.t to the existing cluster).

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb-operator/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced TLS configuration for webhook server with customizable cipher suites, minimum TLS version, and curve preferences
  * Added support for external metallb webhook server deployment

* **Chores**
  * Updated RBAC permissions for pod management operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->