### PR TITLE
WIP: Add custom metallb-speaker SCC for OCP speaker pods

### DIFF
--- a/config/metallb_rbac/metallb-openshift.yaml
+++ b/config/metallb_rbac/metallb-openshift.yaml
@@ -177,7 +177,7 @@ rules:
   - apiGroups:
       - security.openshift.io
     resourceNames:
-      - privileged
+      - metallb-speaker
     resources:
       - securitycontextconstraints
     verbs:

--- a/config/metallb_rbac/speaker_role_binding.yaml
+++ b/config/metallb_rbac/speaker_role_binding.yaml
@@ -7,7 +7,7 @@ rules:
   - apiGroups:
       - security.openshift.io
     resourceNames:
-      - privileged
+      - metallb-speaker
     resources:
       - securitycontextconstraints
     verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -122,6 +122,20 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - metallb-speaker
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/controllers/metallb_controller.go
+++ b/controllers/metallb_controller.go
@@ -81,6 +81,7 @@ var EmbeddedFRRK8sSupportNotAvailable = errors.New("current CNO version does not
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=create;delete;get;update;patch;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=create;delete;get;update;patch;list;watch
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=networks,verbs=get;list;watch;update;
+// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=metallb-speaker,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers;clusteroperators,verbs=get;list;watch;
 
 func (r *MetalLBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/hack/ocp-kustomize-overlay/rbac.yaml
+++ b/hack/ocp-kustomize-overlay/rbac.yaml
@@ -22,10 +22,32 @@ roleRef:
   name: allow-privileged
 subjects:
   - kind: ServiceAccount
-    name: speaker
-    namespace: metallb-system
-  - kind: ServiceAccount
     name: frr-k8s-daemon
     namespace: metallb-system
 ---
-
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metallb-speaker-scc
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - metallb-speaker
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metallb-speaker-scc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-speaker-scc
+subjects:
+  - kind: ServiceAccount
+    name: speaker
+    namespace: metallb-system

--- a/manifests/stable/metallb-operator.clusterserviceversion.yaml
+++ b/manifests/stable/metallb-operator.clusterserviceversion.yaml
@@ -747,6 +747,20 @@ spec:
                 - patch
                 - update
                 - watch
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - metallb-speaker
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
           serviceAccountName: manager-account
         - rules:
             - apiGroups:
@@ -1287,7 +1301,7 @@ spec:
             - apiGroups:
                 - security.openshift.io
               resourceNames:
-                - privileged
+                - metallb-speaker
               resources:
                 - securitycontextconstraints
               verbs:

--- a/pkg/helm/config.go
+++ b/pkg/helm/config.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	metallbv1beta1 "github.com/metallb/metallb-operator/api/v1beta1"
+	"github.com/metallb/metallb-operator/pkg/openshift"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -115,6 +116,18 @@ func ocpServiceMonitorTLSConfig(component, namespace string) map[string]interfac
 		"keyFile":            "/etc/prometheus/secrets/metrics-client-certs/tls.key",
 		"insecureSkipVerify": false,
 	}
+}
+
+func setRequiredSCCAnnotationForSpeaker(obj *unstructured.Unstructured) error {
+	annotations, _, err := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
+	if err != nil {
+		return err
+	}
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations["openshift.io/required-scc"] = openshift.SpeakerSCCName
+	return unstructured.SetNestedStringMap(obj.Object, annotations, "spec", "template", "metadata", "annotations")
 }
 
 func updateAnnotations(obj *unstructured.Unstructured, annotations map[string]string) error {

--- a/pkg/helm/metallb.go
+++ b/pkg/helm/metallb.go
@@ -18,6 +18,7 @@ package helm
 
 import (
 	metallbv1beta1 "github.com/metallb/metallb-operator/api/v1beta1"
+	"github.com/metallb/metallb-operator/pkg/openshift"
 	"github.com/metallb/metallb-operator/pkg/params"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -86,12 +87,20 @@ func (h *MetalLBChart) Objects(envConfig params.EnvConfig, crdConfig *metallbv1b
 				return nil, err
 			}
 		}
+		if isSpeakerDaemonSet(obj) && envConfig.IsOpenshift {
+			if err := setRequiredSCCAnnotationForSpeaker(obj); err != nil {
+				return nil, err
+			}
+		}
 		if isServiceMonitor(obj) && envConfig.IsOpenshift {
 			err := setOcpMonitorFields(obj)
 			if err != nil {
 				return nil, err
 			}
 		}
+	}
+	if envConfig.IsOpenshift {
+		objs = append(objs, openshift.SpeakerSCC())
 	}
 	return objs, nil
 }

--- a/pkg/helm/testdata/ocp-metrics-speaker.golden
+++ b/pkg/helm/testdata/ocp-metrics-speaker.golden
@@ -21,6 +21,9 @@
         },
         "template": {
             "metadata": {
+                "annotations": {
+                    "openshift.io/required-scc": "metallb-speaker"
+                },
                 "labels": {
                     "app": "metallb",
                     "component": "speaker"

--- a/pkg/openshift/scc.go
+++ b/pkg/openshift/scc.go
@@ -1,0 +1,59 @@
+package openshift
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const SpeakerSCCName = "metallb-speaker"
+
+func SpeakerSCC() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "security.openshift.io/v1",
+			"kind":       "SecurityContextConstraints",
+			"metadata": map[string]interface{}{
+				"name": SpeakerSCCName,
+				"annotations": map[string]interface{}{
+					"kubernetes.io/description": "Custom SCC for MetalLB speaker. Grants only host networking and NET_RAW capability required for L2/ARP operations.",
+				},
+			},
+			"allowHostDirVolumePlugin": false,
+			"allowHostIPC":             false,
+			"allowHostNetwork":         true,
+			"allowHostPID":             false,
+			"allowHostPorts":           true,
+			"allowPrivilegeEscalation": false,
+			"allowPrivilegedContainer": false,
+			"allowedCapabilities": []interface{}{
+				"NET_RAW",
+			},
+			"defaultAddCapabilities": []interface{}{},
+			"fsGroup": map[string]interface{}{
+				"type": "RunAsAny",
+			},
+			"readOnlyRootFilesystem": false,
+			"requiredDropCapabilities": []interface{}{
+				"ALL",
+			},
+			"runAsUser": map[string]interface{}{
+				"type": "RunAsAny",
+			},
+			"seLinuxContext": map[string]interface{}{
+				"type": "RunAsAny",
+			},
+			"supplementalGroups": map[string]interface{}{
+				"type": "RunAsAny",
+			},
+			"volumes": []interface{}{
+				"configMap",
+				"downwardAPI",
+				"emptyDir",
+				"projected",
+				"secret",
+			},
+			"users":    []interface{}{},
+			"groups":   []interface{}{},
+			"priority": nil,
+		},
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated OpenShift SecurityContextConstraints (SCC) for the MetalLB speaker (`metallb-speaker`).
  * Helm now annotates the speaker DaemonSet to request the required SCC on OpenShift.
* **Bug Fixes**
  * Updated OpenShift RBAC to grant permissions specifically for the `metallb-speaker` SCC (instead of `privileged`).
  * Updated the operator ClusterServiceVersion and controller RBAC to align with the new SCC.
* **Tests**
  * Updated Helm golden rendering for the annotated DaemonSet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->