### PR TITLE
OCPBUGS-104452: Fix TLS ciphers for MinVersion=1.3

### DIFF
--- a/pkg/tlsconfig/tlsopt.go
+++ b/pkg/tlsconfig/tlsopt.go
@@ -16,9 +16,6 @@ import (
 // Cipher suites are IANA names (comma-separated).
 // Curve preferences are numeric CurveID values (comma-separated).
 // Min version is a Go TLS version string (e.g. "VersionTLS12").
-//
-// Returns an error if cipher suites are specified with TLS 1.3 minimum,
-// since Go's TLS 1.3 does not allow configuring cipher suites.
 func OptFor(cipherSuites, curvePreferences, minVersion string) (func(*tls.Config), error) {
 	ciphers, err := parseCipherSuites(cipherSuites)
 	if err != nil {
@@ -31,9 +28,6 @@ func OptFor(cipherSuites, curvePreferences, minVersion string) (func(*tls.Config
 	minVer, err := parseTLSVersion(minVersion)
 	if err != nil {
 		return nil, fmt.Errorf("parsing tls-min-version: %w", err)
-	}
-	if ciphers != nil && minVer == tls.VersionTLS13 {
-		return nil, fmt.Errorf("cipher suites cannot be configured with TLS 1.3")
 	}
 	return func(cfg *tls.Config) {
 		if ciphers != nil {

--- a/pkg/tlsconfig/tlsopt_test.go
+++ b/pkg/tlsconfig/tlsopt_test.go
@@ -175,10 +175,11 @@ func TestOptFor(t *testing.T) {
 			wantMinVersion:       tls.VersionTLS13,
 		},
 		{
-			name:         "rejects cipher suites with TLS 1.3",
-			cipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-			minVersion:   "VersionTLS13",
-			wantErrMsg:   "cipher suites cannot be configured with TLS 1.3",
+			name:             "TLS 1.3 with ciphers passes through",
+			cipherSuites:     "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			minVersion:       "VersionTLS13",
+			wantCipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+			wantMinVersion:   tls.VersionTLS13,
 		},
 		{
 			name:         "invalid cipher returns error",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TLS 1.3 configurations that specify cipher suites are now accepted.
  * Configured cipher suites are preserved without triggering a validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->